### PR TITLE
피드 리스트를 네트워크와 통신하기 위해 NetworkService,RecipeFetchService를 생성,피드리스트 UI에 관련된 객체만들 정의 하는 RecipeListItemViewModel을 정의

### DIFF
--- a/HomeCafeRecipes/HomeCafeRecipes.xcodeproj/project.pbxproj
+++ b/HomeCafeRecipes/HomeCafeRecipes.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		1D2C16FD2BE532B800C04508 /* HomeCafeRecipesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2C16FC2BE532B800C04508 /* HomeCafeRecipesTests.swift */; };
 		1D2C17072BE532B800C04508 /* HomeCafeRecipesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2C17062BE532B800C04508 /* HomeCafeRecipesUITests.swift */; };
 		1D2C17092BE532B800C04508 /* HomeCafeRecipesUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2C17082BE532B800C04508 /* HomeCafeRecipesUITestsLaunchTests.swift */; };
+		1D6C5ACF2C1A8C580052A36C /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 1D6C5ACE2C1A8C580052A36C /* Kingfisher */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -342,6 +343,7 @@
 			mainGroup = 1D2C16D92BE532B700C04508;
 			packageReferences = (
 				1D740B3F2C15E1EC0001B704 /* XCRemoteSwiftPackageReference "RxSwift" */,
+				1D6C5ACD2C1A8C580052A36C /* XCRemoteSwiftPackageReference "Kingfisher" */,
 			);
 			productRefGroup = 1D2C16E32BE532B700C04508 /* Products */;
 			projectDirPath = "";
@@ -739,6 +741,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		1D6C5ACD2C1A8C580052A36C /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.12.0;
+			};
+		};
 		1D740B3F2C15E1EC0001B704 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactiveX/RxSwift";

--- a/HomeCafeRecipes/HomeCafeRecipes.xcodeproj/project.pbxproj
+++ b/HomeCafeRecipes/HomeCafeRecipes.xcodeproj/project.pbxproj
@@ -17,22 +17,32 @@
 		1D1283B12C1697DB00C5A870 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1D1283B02C1697DB00C5A870 /* RxSwift */; };
 		1D1283B42C16983900C5A870 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1D1283B32C16983900C5A870 /* RxSwift */; };
 		1D1283B62C16984E00C5A870 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 1D1283B52C16984E00C5A870 /* RxCocoa */; };
-		1D1283B82C169C0200C5A870 /* FeedListRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1283B72C169C0200C5A870 /* FeedListRepository.swift */; };
-		1D1283BA2C16A62800C5A870 /* SearchFeedListRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1283B92C16A62800C5A870 /* SearchFeedListRepository.swift */; };
-		1D1283C12C16B05800C5A870 /* RecipeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1283C02C16B05800C5A870 /* RecipeDTO.swift */; };
-		1D1283C32C16B06F00C5A870 /* UserDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1283C22C16B06F00C5A870 /* UserDTO.swift */; };
-		1D1283C52C16B07D00C5A870 /* CommentDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1283C42C16B07D00C5A870 /* CommentDTO.swift */; };
 		1D1283C82C16CE7C00C5A870 /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1283C72C16CE7C00C5A870 /* DateFormatter+Extensions.swift */; };
 		1D1283CA2C16D9C600C5A870 /* RecipeFetchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1283C92C16D9C600C5A870 /* RecipeFetchService.swift */; };
 		1D2C16E62BE532B700C04508 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2C16E52BE532B700C04508 /* AppDelegate.swift */; };
-		1D2C16E82BE532B700C04508 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2C16E72BE532B700C04508 /* SceneDelegate.swift */; };
 		1D2C16EA2BE532B700C04508 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2C16E92BE532B700C04508 /* ViewController.swift */; };
-		1D2C16EF2BE532B800C04508 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1D2C16EE2BE532B800C04508 /* Assets.xcassets */; };
-		1D2C16F22BE532B800C04508 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1D2C16F02BE532B800C04508 /* LaunchScreen.storyboard */; };
 		1D2C16FD2BE532B800C04508 /* HomeCafeRecipesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2C16FC2BE532B800C04508 /* HomeCafeRecipesTests.swift */; };
 		1D2C17072BE532B800C04508 /* HomeCafeRecipesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2C17062BE532B800C04508 /* HomeCafeRecipesUITests.swift */; };
 		1D2C17092BE532B800C04508 /* HomeCafeRecipesUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2C17082BE532B800C04508 /* HomeCafeRecipesUITestsLaunchTests.swift */; };
-		1D6C5ACF2C1A8C580052A36C /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 1D6C5ACE2C1A8C580052A36C /* Kingfisher */; };
+		1D4741D12C1B4F8D009381CE /* RecipeImageDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4741CC2C1B4F8D009381CE /* RecipeImageDTO.swift */; };
+		1D4741D22C1B4F8D009381CE /* RecipeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4741CD2C1B4F8D009381CE /* RecipeDTO.swift */; };
+		1D4741D32C1B4F8D009381CE /* RecipePageDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4741CE2C1B4F8D009381CE /* RecipePageDTO.swift */; };
+		1D4741D42C1B4F8D009381CE /* NetworkResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4741CF2C1B4F8D009381CE /* NetworkResponseDTO.swift */; };
+		1D4741D52C1B4F8D009381CE /* UserDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4741D02C1B4F8D009381CE /* UserDTO.swift */; };
+		1D4741D72C1B4FF4009381CE /* RecipeListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4741D62C1B4FF4009381CE /* RecipeListViewModel.swift */; };
+		1DDFFD812C1C096A0083B077 /* RecipeMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDFFD802C1C096A0083B077 /* RecipeMapper.swift */; };
+		1DE19E9D2C1B3DC10031804A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE19E9C2C1B3DC10031804A /* SceneDelegate.swift */; };
+		1DE19EA72C1B420A0031804A /* FeedListRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE19EA52C1B420A0031804A /* FeedListRepository.swift */; };
+		1DE19EA82C1B420A0031804A /* SearchFeedListRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE19EA62C1B420A0031804A /* SearchFeedListRepository.swift */; };
+		1DE19EB12C1B42200031804A /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE19EB02C1B42200031804A /* NetworkService.swift */; };
+		1DE19EBF2C1B422F0031804A /* RecipeItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE19EB42C1B422F0031804A /* RecipeItemViewModel.swift */; };
+		1DE19EC02C1B422F0031804A /* RecipeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE19EB62C1B422F0031804A /* RecipeDetailView.swift */; };
+		1DE19EC22C1B422F0031804A /* RecipeListItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE19EBA2C1B422F0031804A /* RecipeListItemViewModel.swift */; };
+		1DE19EC32C1B422F0031804A /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE19EBB2C1B422F0031804A /* SearchBar.swift */; };
+		1DE19EC42C1B422F0031804A /* RecipeListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE19EBC2C1B422F0031804A /* RecipeListViewController.swift */; };
+		1DE19EC52C1B422F0031804A /* RecipeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE19EBD2C1B422F0031804A /* RecipeListView.swift */; };
+		1DE19EC62C1B422F0031804A /* RecipeListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE19EBE2C1B422F0031804A /* RecipeListCell.swift */; };
+		1DE19EC82C1B4C2D0031804A /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 1DE19EC72C1B4C2D0031804A /* Kingfisher */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,16 +69,10 @@
 		1D1283A72C15EABB00C5A870 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		1D1283A92C15EBCF00C5A870 /* SearchFeedUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFeedUseCase.swift; sourceTree = "<group>"; };
 		1D1283AB2C15EBE600C5A870 /* FetchFeedListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchFeedListUseCase.swift; sourceTree = "<group>"; };
-		1D1283B72C169C0200C5A870 /* FeedListRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedListRepository.swift; sourceTree = "<group>"; };
-		1D1283B92C16A62800C5A870 /* SearchFeedListRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFeedListRepository.swift; sourceTree = "<group>"; };
-		1D1283C02C16B05800C5A870 /* RecipeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeDTO.swift; sourceTree = "<group>"; };
-		1D1283C22C16B06F00C5A870 /* UserDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDTO.swift; sourceTree = "<group>"; };
-		1D1283C42C16B07D00C5A870 /* CommentDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentDTO.swift; sourceTree = "<group>"; };
 		1D1283C72C16CE7C00C5A870 /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
 		1D1283C92C16D9C600C5A870 /* RecipeFetchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeFetchService.swift; sourceTree = "<group>"; };
 		1D2C16E22BE532B700C04508 /* HomeCafeRecipes.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HomeCafeRecipes.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1D2C16E52BE532B700C04508 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		1D2C16E72BE532B700C04508 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		1D2C16E92BE532B700C04508 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		1D2C16EE2BE532B800C04508 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1D2C16F12BE532B800C04508 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -78,6 +82,24 @@
 		1D2C17022BE532B800C04508 /* HomeCafeRecipesUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HomeCafeRecipesUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1D2C17062BE532B800C04508 /* HomeCafeRecipesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCafeRecipesUITests.swift; sourceTree = "<group>"; };
 		1D2C17082BE532B800C04508 /* HomeCafeRecipesUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCafeRecipesUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		1D4741CC2C1B4F8D009381CE /* RecipeImageDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeImageDTO.swift; sourceTree = "<group>"; };
+		1D4741CD2C1B4F8D009381CE /* RecipeDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeDTO.swift; sourceTree = "<group>"; };
+		1D4741CE2C1B4F8D009381CE /* RecipePageDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipePageDTO.swift; sourceTree = "<group>"; };
+		1D4741CF2C1B4F8D009381CE /* NetworkResponseDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkResponseDTO.swift; sourceTree = "<group>"; };
+		1D4741D02C1B4F8D009381CE /* UserDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDTO.swift; sourceTree = "<group>"; };
+		1D4741D62C1B4FF4009381CE /* RecipeListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeListViewModel.swift; sourceTree = "<group>"; };
+		1DDFFD802C1C096A0083B077 /* RecipeMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeMapper.swift; sourceTree = "<group>"; };
+		1DE19E9C2C1B3DC10031804A /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		1DE19EA52C1B420A0031804A /* FeedListRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedListRepository.swift; sourceTree = "<group>"; };
+		1DE19EA62C1B420A0031804A /* SearchFeedListRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchFeedListRepository.swift; sourceTree = "<group>"; };
+		1DE19EB02C1B42200031804A /* NetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
+		1DE19EB42C1B422F0031804A /* RecipeItemViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeItemViewModel.swift; sourceTree = "<group>"; };
+		1DE19EB62C1B422F0031804A /* RecipeDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeDetailView.swift; sourceTree = "<group>"; };
+		1DE19EBA2C1B422F0031804A /* RecipeListItemViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeListItemViewModel.swift; sourceTree = "<group>"; };
+		1DE19EBB2C1B422F0031804A /* SearchBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
+		1DE19EBC2C1B422F0031804A /* RecipeListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeListViewController.swift; sourceTree = "<group>"; };
+		1DE19EBD2C1B422F0031804A /* RecipeListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeListView.swift; sourceTree = "<group>"; };
+		1DE19EBE2C1B422F0031804A /* RecipeListCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeListCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +107,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1DE19EC82C1B4C2D0031804A /* Kingfisher in Frameworks */,
 				1D1283B12C1697DB00C5A870 /* RxSwift in Frameworks */,
 				1D1283AF2C1697DB00C5A870 /* RxCocoa in Frameworks */,
 			);
@@ -132,8 +155,8 @@
 		1D1283AD2C16974B00C5A870 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				1DE19EA42C1B420A0031804A /* Repositories */,
 				1D1283BC2C16AA8100C5A870 /* Network */,
-				1D1283BB2C16AA6400C5A870 /* Repositories */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -145,33 +168,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		1D1283BB2C16AA6400C5A870 /* Repositories */ = {
-			isa = PBXGroup;
-			children = (
-				1D1283B72C169C0200C5A870 /* FeedListRepository.swift */,
-				1D1283B92C16A62800C5A870 /* SearchFeedListRepository.swift */,
-			);
-			name = Repositories;
-			path = "ㄲ데ㅐ냐새갿ㄴ";
-			sourceTree = "<group>";
-		};
 		1D1283BC2C16AA8100C5A870 /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				1D1283BF2C16B02600C5A870 /* DTO */,
+				1D4741CB2C1B4F8D009381CE /* DTO */,
 				1D1283C92C16D9C600C5A870 /* RecipeFetchService.swift */,
+				1DE19EB02C1B42200031804A /* NetworkService.swift */,
 			);
 			path = Network;
-			sourceTree = "<group>";
-		};
-		1D1283BF2C16B02600C5A870 /* DTO */ = {
-			isa = PBXGroup;
-			children = (
-				1D1283C02C16B05800C5A870 /* RecipeDTO.swift */,
-				1D1283C22C16B06F00C5A870 /* UserDTO.swift */,
-				1D1283C42C16B07D00C5A870 /* CommentDTO.swift */,
-			);
-			path = DTO;
 			sourceTree = "<group>";
 		};
 		1D1283C62C16CD9200C5A870 /* Utilities */ = {
@@ -192,6 +196,7 @@
 				1D1283B22C16983900C5A870 /* Frameworks */,
 			);
 			sourceTree = "<group>";
+			wrapsLines = 1;
 		};
 		1D2C16E32BE532B700C04508 /* Products */ = {
 			isa = PBXGroup;
@@ -206,11 +211,12 @@
 		1D2C16E42BE532B700C04508 /* HomeCafeRecipes */ = {
 			isa = PBXGroup;
 			children = (
+				1DE19EB22C1B422F0031804A /* Presentation */,
 				1D1283C62C16CD9200C5A870 /* Utilities */,
 				1D1283AD2C16974B00C5A870 /* Data */,
 				1D740B402C15E6680001B704 /* Domain */,
 				1D2C16E52BE532B700C04508 /* AppDelegate.swift */,
-				1D2C16E72BE532B700C04508 /* SceneDelegate.swift */,
+				1DE19E9C2C1B3DC10031804A /* SceneDelegate.swift */,
 				1D2C16E92BE532B700C04508 /* ViewController.swift */,
 				1D2C16EE2BE532B800C04508 /* Assets.xcassets */,
 				1D2C16F02BE532B800C04508 /* LaunchScreen.storyboard */,
@@ -236,13 +242,98 @@
 			path = HomeCafeRecipesUITests;
 			sourceTree = "<group>";
 		};
+		1D4741CB2C1B4F8D009381CE /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				1D4741CC2C1B4F8D009381CE /* RecipeImageDTO.swift */,
+				1D4741CD2C1B4F8D009381CE /* RecipeDTO.swift */,
+				1D4741CE2C1B4F8D009381CE /* RecipePageDTO.swift */,
+				1D4741CF2C1B4F8D009381CE /* NetworkResponseDTO.swift */,
+				1D4741D02C1B4F8D009381CE /* UserDTO.swift */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
 		1D740B402C15E6680001B704 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				1DE19EA12C1B41FE0031804A /* ViewModel */,
 				1D1283A02C15E92C00C5A870 /* UseCases */,
 				1D12839F2C15E7A700C5A870 /* Entities */,
 			);
 			path = Domain;
+			sourceTree = "<group>";
+		};
+		1DDFFD822C1C09AB0083B077 /* Mapper */ = {
+			isa = PBXGroup;
+			children = (
+				1DDFFD802C1C096A0083B077 /* RecipeMapper.swift */,
+			);
+			path = Mapper;
+			sourceTree = "<group>";
+		};
+		1DE19EA12C1B41FE0031804A /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				1D4741D62C1B4FF4009381CE /* RecipeListViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		1DE19EA42C1B420A0031804A /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				1DE19EA52C1B420A0031804A /* FeedListRepository.swift */,
+				1DE19EA62C1B420A0031804A /* SearchFeedListRepository.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
+		1DE19EB22C1B422F0031804A /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				1DDFFD822C1C09AB0083B077 /* Mapper */,
+				1DE19EB32C1B422F0031804A /* Feed */,
+				1DE19EB72C1B422F0031804A /* FeedList */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		1DE19EB32C1B422F0031804A /* Feed */ = {
+			isa = PBXGroup;
+			children = (
+				1DE19EB42C1B422F0031804A /* RecipeItemViewModel.swift */,
+				1DE19EB52C1B422F0031804A /* View */,
+			);
+			path = Feed;
+			sourceTree = "<group>";
+		};
+		1DE19EB52C1B422F0031804A /* View */ = {
+			isa = PBXGroup;
+			children = (
+				1DE19EB62C1B422F0031804A /* RecipeDetailView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		1DE19EB72C1B422F0031804A /* FeedList */ = {
+			isa = PBXGroup;
+			children = (
+				1DE19EB92C1B422F0031804A /* View */,
+			);
+			path = FeedList;
+			sourceTree = "<group>";
+		};
+		1DE19EB92C1B422F0031804A /* View */ = {
+			isa = PBXGroup;
+			children = (
+				1DE19EBA2C1B422F0031804A /* RecipeListItemViewModel.swift */,
+				1DE19EBB2C1B422F0031804A /* SearchBar.swift */,
+				1DE19EBC2C1B422F0031804A /* RecipeListViewController.swift */,
+				1DE19EBD2C1B422F0031804A /* RecipeListView.swift */,
+				1DE19EBE2C1B422F0031804A /* RecipeListCell.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -264,6 +355,7 @@
 			packageProductDependencies = (
 				1D1283AE2C1697DB00C5A870 /* RxCocoa */,
 				1D1283B02C1697DB00C5A870 /* RxSwift */,
+				1DE19EC72C1B4C2D0031804A /* Kingfisher */,
 			);
 			productName = HomeCafeRecipes;
 			productReference = 1D2C16E22BE532B700C04508 /* HomeCafeRecipes.app */;
@@ -361,8 +453,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1D2C16F22BE532B800C04508 /* LaunchScreen.storyboard in Resources */,
-				1D2C16EF2BE532B800C04508 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -388,21 +478,33 @@
 			buildActionMask = 2147483647;
 			files = (
 				1D2C16EA2BE532B700C04508 /* ViewController.swift in Sources */,
+				1DE19EC52C1B422F0031804A /* RecipeListView.swift in Sources */,
+				1D4741D32C1B4F8D009381CE /* RecipePageDTO.swift in Sources */,
 				1D2C16E62BE532B700C04508 /* AppDelegate.swift in Sources */,
+				1DE19EB12C1B42200031804A /* NetworkService.swift in Sources */,
 				1D1283A62C15EAA600C5A870 /* User.swift in Sources */,
-				1D1283C52C16B07D00C5A870 /* CommentDTO.swift in Sources */,
 				1D1283AC2C15EBE600C5A870 /* FetchFeedListUseCase.swift in Sources */,
 				1D1283A82C15EABB00C5A870 /* Comment.swift in Sources */,
 				1D1283C82C16CE7C00C5A870 /* DateFormatter+Extensions.swift in Sources */,
-				1D1283B82C169C0200C5A870 /* FeedListRepository.swift in Sources */,
 				1D1283A42C15EA8100C5A870 /* RecipeType.swift in Sources */,
+				1D4741D22C1B4F8D009381CE /* RecipeDTO.swift in Sources */,
+				1DE19EC02C1B422F0031804A /* RecipeDetailView.swift in Sources */,
 				1D1283AA2C15EBCF00C5A870 /* SearchFeedUseCase.swift in Sources */,
-				1D2C16E82BE532B700C04508 /* SceneDelegate.swift in Sources */,
-				1D1283BA2C16A62800C5A870 /* SearchFeedListRepository.swift in Sources */,
+				1DE19EA82C1B420A0031804A /* SearchFeedListRepository.swift in Sources */,
+				1D4741D52C1B4F8D009381CE /* UserDTO.swift in Sources */,
+				1DE19EC22C1B422F0031804A /* RecipeListItemViewModel.swift in Sources */,
+				1DE19EC32C1B422F0031804A /* SearchBar.swift in Sources */,
+				1D4741D72C1B4FF4009381CE /* RecipeListViewModel.swift in Sources */,
+				1DE19E9D2C1B3DC10031804A /* SceneDelegate.swift in Sources */,
+				1D4741D12C1B4F8D009381CE /* RecipeImageDTO.swift in Sources */,
+				1DE19EA72C1B420A0031804A /* FeedListRepository.swift in Sources */,
+				1DE19EC62C1B422F0031804A /* RecipeListCell.swift in Sources */,
+				1DDFFD812C1C096A0083B077 /* RecipeMapper.swift in Sources */,
+				1DE19EC42C1B422F0031804A /* RecipeListViewController.swift in Sources */,
+				1DE19EBF2C1B422F0031804A /* RecipeItemViewModel.swift in Sources */,
 				1D1283A22C15E94300C5A870 /* Recipe.swift in Sources */,
 				1D1283CA2C16D9C600C5A870 /* RecipeFetchService.swift in Sources */,
-				1D1283C32C16B06F00C5A870 /* UserDTO.swift in Sources */,
-				1D1283C12C16B05800C5A870 /* RecipeDTO.swift in Sources */,
+				1D4741D42C1B4F8D009381CE /* NetworkResponseDTO.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -779,6 +881,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 1D740B3F2C15E1EC0001B704 /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = RxCocoa;
+		};
+		1DE19EC72C1B4C2D0031804A /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1D6C5ACD2C1A8C580052A36C /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/HomeCafeRecipes/HomeCafeRecipes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HomeCafeRecipes/HomeCafeRecipes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "2ef543ee21d63734e1c004ad6c870255e8716c50",
+        "version" : "7.12.0"
+      }
+    },
+    {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveX/RxSwift",

--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Network/NetworkService.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Network/NetworkService.swift
@@ -1,0 +1,43 @@
+//
+//  NetworkService.swift
+//  HomeCafeRecipes
+//
+//  Created by 김건호 on 6/12/24.
+//
+
+import Foundation
+import RxSwift
+
+protocol NetworkService {
+    func getRequest<T: Decodable>(url: URL, responseType: T.Type) -> Single<T>
+}
+
+class BaseNetworkService: NetworkService {
+    let baseURL = URL(string: "https://meog0.store/api")!
+    
+    func getRequest<T: Decodable>(url: URL, responseType: T.Type) -> Single<T> {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        return Single.create { single in
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                if let error = error {
+                    single(.failure(error))
+                } else if let data = data {
+                    do {
+                        let decoder = JSONDecoder()
+                        decoder.dateDecodingStrategy = .iso8601
+                        let responseObject = try decoder.decode(T.self, from: data)
+                        single(.success(responseObject))
+                    } catch let decodingError {
+                        single(.failure(decodingError))
+                    }
+                }
+            }
+            task.resume()
+            
+            return Disposables.create {
+                task.cancel()
+            }
+        }
+    }
+}

--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Network/RecipeFetchService.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Network/RecipeFetchService.swift
@@ -21,7 +21,7 @@ class DefaultRecipeFetchService: RecipeFetchService {
         self.networkService = networkService
     }
     
-    private func buildURL(endpoint: String, queryItems: [URLQueryItem]) -> URL? {
+    private func makeURL(endpoint: String, queryItems: [URLQueryItem]) -> URL? {
         let URL = DefaultRecipeFetchService.baseURL.appendingPathComponent(endpoint)
         var URLComponents = URLComponents(url: URL, resolvingAgainstBaseURL: false)
         URLComponents?.queryItems = queryItems
@@ -29,7 +29,7 @@ class DefaultRecipeFetchService: RecipeFetchService {
     }
     
     func fetchRecipes(pageNumber: Int) -> Single<[Recipe]> {
-        guard let URL = buildURL(endpoint: "recipes", queryItems: [URLQueryItem(name: "pageNumber", value: String(pageNumber))]) else {
+        guard let URL = makeURL(endpoint: "recipes", queryItems: [URLQueryItem(name: "pageNumber", value: String(pageNumber))]) else {
             return Single.error(NSError(domain: "URLComponentsError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid URL"]))
         }
         return networkService.getRequest(url: URL, responseType: NetworkResponseDTO<RecipePageDTO>.self)
@@ -38,7 +38,7 @@ class DefaultRecipeFetchService: RecipeFetchService {
     
     
     func searchRecipes(title: String, pageNumber: Int) -> Single<[Recipe]> {
-        guard let URL = buildURL(endpoint: "recipes", queryItems: [
+        guard let URL = makeURL(endpoint: "recipes", queryItems: [
             URLQueryItem(name: "keyword", value: title),
             URLQueryItem(name: "pageNumber", value: String(pageNumber))
         ]) else {

--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Network/RecipeFetchService.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Network/RecipeFetchService.swift
@@ -1,0 +1,50 @@
+//
+//  RecipeFetchService.swift
+//  HomeCafeRecipes
+//
+//  Created by 김건호 on 6/10/24.
+//
+
+import Foundation
+import RxSwift
+
+protocol RecipeFetchService {
+    func fetchRecipes(pageNumber: Int) -> Single<[Recipe]>
+    func searchRecipes(title: String, pageNumber: Int) -> Single<[Recipe]>
+}
+
+class DefaultRecipeFetchService: RecipeFetchService {
+    private let networkService: NetworkService
+    private let baseURL: URL
+    
+    init(networkService: NetworkService, baseURL: URL = URL(string: "https://meog0.store/api")!) {
+        self.networkService = networkService
+        self.baseURL = baseURL
+    }
+    
+    func fetchRecipes(pageNumber: Int) -> Single<[Recipe]> {
+        let url = baseURL.appendingPathComponent("recipes")
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        urlComponents?.queryItems = [URLQueryItem(name: "pageNumber", value: String(pageNumber))]
+        guard let finalURL = urlComponents?.url else {
+            return Single.error(NSError(domain: "URLComponentsError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid URL"]))
+        }
+        return networkService.getRequest(url: finalURL, responseType: NetworkResponseDTO<RecipePageDTO>.self)
+            .map { responseDTO in
+                return responseDTO.data.recipes.map { $0.toDomain() }
+            }
+    }
+    
+    func searchRecipes(title: String, pageNumber: Int) -> Single<[Recipe]> {
+        let url = baseURL.appendingPathComponent("recipes")
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        urlComponents?.queryItems = [URLQueryItem(name: "keyword", value: title), URLQueryItem(name: "pageNumber", value: String(pageNumber))]
+        guard let finalURL = urlComponents?.url else {
+            return Single.error(NSError(domain: "URLComponentsError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid URL"]))
+        }
+        return networkService.getRequest(url: finalURL, responseType: NetworkResponseDTO<RecipePageDTO>.self)
+            .map { responseDTO in
+                return responseDTO.data.recipes.map { $0.toDomain() }
+            }
+    }
+}

--- a/HomeCafeRecipes/HomeCafeRecipes/Domain/ViewModel/RecipeListViewModel.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Domain/ViewModel/RecipeListViewModel.swift
@@ -79,9 +79,9 @@ class RecipeListViewModel: InputRecipeListViewModel, OutputRecipeListViewModel {
     func viewDidLoad() {
         fetchRecipes()
     }
-
+    
     func fetchNextPage() {
-        fetchRecipes()
+        fetchNextRecipes(nextPage: currentPage)
     }
 
     func didSelectItem(id: Int) -> RecipeItemViewModel? {
@@ -117,11 +117,22 @@ class RecipeListViewModel: InputRecipeListViewModel, OutputRecipeListViewModel {
             .subscribe(onSuccess: handleSuccess, onFailure: handleError)
             .disposed(by: disposeBag)
     }
+    
+    private func fetchNextRecipes(nextPage: Int){
+        guard !isFetching else { return }
+        isFetching = true
+        fetchFeedListUseCase.execute(pageNumber: nextPage)
+            .subscribe(onSuccess: handleSuccess, onFailure: handleError)
+            .disposed(by: disposeBag)
+    }
 
     private func handleSuccess(result: Result<[Recipe], Error>) {
         isFetching = false
         switch result {
         case .success(let recipes):
+            if recipes.isEmpty {
+                return
+            }
             if currentPage == 1 {
                 allRecipes = recipes
             } else {

--- a/HomeCafeRecipes/HomeCafeRecipes/Domain/ViewModel/RecipeListViewModel.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Domain/ViewModel/RecipeListViewModel.swift
@@ -10,7 +10,7 @@ import RxSwift
 
 protocol RecipeListViewModelDelegate: AnyObject {
     func didFetchRecipes(_ recipes: [RecipeListItemViewModel])
-    func didFailWithError(_ error: Error)
+    func didFail(with error: Error)
 }
 
 protocol InputRecipeListViewModel {
@@ -70,7 +70,7 @@ class RecipeListViewModel: InputRecipeListViewModel, OutputRecipeListViewModel {
         error
             .subscribe(onNext: { [weak self] error in
                 if let error = error {
-                    self?.delegate?.didFailWithError(error)
+                    self?.delegate?.didFail(with: error)
                 }
             })
             .disposed(by: disposeBag)

--- a/HomeCafeRecipes/HomeCafeRecipes/Domain/ViewModel/RecipeListViewModel.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Domain/ViewModel/RecipeListViewModel.swift
@@ -1,0 +1,133 @@
+//
+//  RecipeListViewModel.swift
+//  HomeCafeRecipes
+//
+//  Created by 김건호 on 6/10/24.
+//
+
+import Foundation
+import RxSwift
+
+protocol RecipeListViewModelDelegate: AnyObject {
+    func didFetchRecipes(_ recipes: [RecipeListItemViewModel])
+    func didFailWithError(_ error: Error)
+}
+
+protocol InputRecipeListViewModel {
+    func viewDidLoad()
+    func fetchNextPage()
+    func didSelectItem(id: Int)
+    func searchRecipes(with query: String)
+}
+
+protocol OutputRecipeListViewModel {
+    var recipes: Observable<[RecipeListItemViewModel]> { get }
+    var error: Observable<Error?> { get }
+}
+
+class RecipeListViewModel: InputRecipeListViewModel, OutputRecipeListViewModel {
+    
+    private let disposeBag = DisposeBag()
+    private let fetchFeedListUseCase: FetchFeedListUseCase
+    private let searchFeedListUseCase: SearchFeedListUseCase
+    private weak var delegate: RecipeListViewModelDelegate?
+
+    private var currentPage: Int = 1
+    private var isFetching = false
+    private var isSearching = false
+    private var currentSearchQuery: String?
+    
+    private let recipesSubject = BehaviorSubject<[RecipeListItemViewModel]>(value: [])
+    private let errorSubject = BehaviorSubject<Error?>(value: nil)
+
+    var recipes: Observable<[RecipeListItemViewModel]> {
+        return recipesSubject.asObservable()
+    }
+
+    var error: Observable<Error?> {
+        return errorSubject.asObservable()
+    }
+
+    init(fetchFeedListUseCase: FetchFeedListUseCase, searchFeedListUseCase: SearchFeedListUseCase) {
+        self.fetchFeedListUseCase = fetchFeedListUseCase
+        self.searchFeedListUseCase = searchFeedListUseCase
+    }
+
+    func setDelegate(_ delegate: RecipeListViewModelDelegate) {
+        self.delegate = delegate
+        bindOutputs()
+    }
+
+    private func bindOutputs() {
+        recipes
+            .subscribe(onNext: { [weak self] recipes in
+                self?.delegate?.didFetchRecipes(recipes)
+            })
+            .disposed(by: disposeBag)
+
+        error
+            .subscribe(onNext: { [weak self] error in
+                if let error = error {
+                    self?.delegate?.didFailWithError(error)
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+
+    func viewDidLoad() {
+        fetchRecipes()
+    }
+
+    func fetchNextPage() {
+        fetchRecipes()
+    }
+
+    func didSelectItem(id: Int) {
+        print(id)
+    }
+
+    func searchRecipes(with title: String) {
+        guard !isFetching else { return }
+        isFetching = true
+        currentSearchQuery = title
+        isSearching = true
+        currentPage = 1
+
+        searchFeedListUseCase.execute(title: title, pageNumber: currentPage)
+            .subscribe(onSuccess: handleSuccess, onFailure: handleError)
+            .disposed(by: disposeBag)
+    }
+
+    private func fetchRecipes() {
+        guard !isFetching else { return }
+        isFetching = true
+
+        fetchFeedListUseCase.execute(pageNumber: currentPage)
+            .subscribe(onSuccess: handleSuccess, onFailure: handleError)
+            .disposed(by: disposeBag)
+    }
+
+    private func handleSuccess(result: Result<[Recipe], Error>) {
+        isFetching = false
+        switch result {
+        case .success(let recipes):
+            let recipeViewModels = recipes.map { RecipeListItemViewModel(recipe: $0) }
+            var currentRecipes = try! recipesSubject.value()
+            if isSearching {
+                currentRecipes = recipeViewModels
+                isSearching = false
+            } else {
+                currentRecipes.append(contentsOf: recipeViewModels)
+            }
+            recipesSubject.onNext(currentRecipes)
+            currentPage += 1
+        case .failure(let error):
+            errorSubject.onNext(error)
+        }
+    }
+
+    private func handleError(error: Error) {
+        isFetching = false
+        errorSubject.onNext(error)
+    }
+}

--- a/HomeCafeRecipes/HomeCafeRecipes/Presentation/FeedList/View/RecipeListItemViewModel.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Presentation/FeedList/View/RecipeListItemViewModel.swift
@@ -10,11 +10,11 @@ import Foundation
 struct RecipeListItemViewModel {
     let id: Int
     let name: String
-    let imageUrl: URL?
+    let imageURL: URL?
 
     init(recipe: Recipe) {
         self.id = recipe.id
         self.name = recipe.name
-        self.imageUrl = URL(string: recipe.imageUrls.first ?? "")
+        self.imageURL = URL(string: recipe.imageUrls.first ?? "")
     }
 }

--- a/HomeCafeRecipes/HomeCafeRecipes/Presentation/FeedList/View/RecipeListItemViewModel.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Presentation/FeedList/View/RecipeListItemViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  RecipeListItemViewModel.swift
+//  HomeCafeRecipes
+//
+//  Created by 김건호 on 6/12/24.
+//
+
+import Foundation
+
+struct RecipeListItemViewModel {
+    let id: Int
+    let name: String
+    let imageUrl: URL?
+
+    init(recipe: Recipe) {
+        self.id = recipe.id
+        self.name = recipe.name
+        self.imageUrl = URL(string: recipe.imageUrls.first ?? "")
+    }
+}

--- a/HomeCafeRecipes/HomeCafeRecipes/Presentation/Mapper/RecipeMapper.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Presentation/Mapper/RecipeMapper.swift
@@ -1,0 +1,18 @@
+//
+//  RecipeMapper.swift
+//  HomeCafeRecipes
+//
+//  Created by 김건호 on 6/14/24.
+//
+
+import Foundation
+
+struct RecipeMapper {
+    static func mapToRecipeListItemViewModels(from recipes: [Recipe]) -> [RecipeListItemViewModel] {
+        return recipes.map { RecipeListItemViewModel(recipe: $0) }
+    }
+
+    static func mapToRecipeItemViewModel(from recipe: Recipe) -> RecipeItemViewModel {
+        return RecipeItemViewModel(recipe: recipe)
+    }
+}


### PR DESCRIPTION
-  NetworkService 및 RecipeFetchService 생성: 피드 리스트 데이터를 네트워크와 통신하기 위한 서비스를 생성했습니다.
NetworkService에서는 기본적인 API 통신인 Get,Post를 다루고 RecipeFetchService에서는 NetworkService의 getRequest를 통해 서버에 Get 요청을 보냅니다.

- RecipeListItemViewModel 정의: 피드 리스트 UI에 필요한 객체 형태로 데이터를 변환하는 모델입니다.

- RecipeListViewModel 정의: FetchFeedListUseCase와 SearchFeedListUseCase를 사용하여 데이터를 가져오고,이를 RecipeListItemViewModel로 변환하여 ViewController에 전달합니다.
