### PR TITLE
Router를 정의했습니다.

### DIFF
--- a/HomeCafeRecipes/HomeCafeRecipes/Presentation/Feed/View/RecipeDetailViewController.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Presentation/Feed/View/RecipeDetailViewController.swift
@@ -64,3 +64,9 @@ extension RecipeDetailViewController: RecipeDetailInteractorDelegate {
         }
     }
 }
+
+extension RecipeDetailViewController: Drawable {
+    var viewController: UIViewController? {
+        return self
+    }
+}

--- a/HomeCafeRecipes/HomeCafeRecipes/Presentation/FeedList/View/RecipeListView.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Presentation/FeedList/View/RecipeListView.swift
@@ -23,7 +23,6 @@ final class RecipeListView: UIView {
     private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     
     private var recipes: [RecipeListItemViewModel] = []
-    weak var coordinator: RecipeDetailCoordinatorProtocol?
     weak var delegate: RecipeListViewDelegate?
     
     override init(frame: CGRect) {

--- a/HomeCafeRecipes/HomeCafeRecipes/Presentation/FeedList/View/RecipeListViewController.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Presentation/FeedList/View/RecipeListViewController.swift
@@ -13,12 +13,14 @@ final class RecipeListViewController: UIViewController {
     private var recipes: [RecipeListItemViewModel] = []
     private let searchBar = SearchBar()
     private let recipeListView = RecipeListView()
-
-    init(interactor: RecipeListInteractor) {
-        self.interactor = interactor
-        super.init(nibName: nil, bundle: nil)
+    private let recipeListMapper = RecipeListMapper()
+    private let router: RecipeListRouter
+    
+    init(interactor: RecipeListInteractor, router: RecipeListRouter) {
         self.interactor.setDelegate(self)
-        
+        self.interactor = interactor
+        self.router = router
+        super.init(nibName: nil, bundle: nil)        
     }
     
     required init?(coder: NSCoder) {
@@ -90,7 +92,7 @@ extension RecipeListViewController: RecipeListInteractorDelegate {
     }
     
     func showRecipeDetail(ID: Int) {
-        coordinator.showRecipeDetail(from: self, recipeID: ID)
+        router.navigateToRecipeDetail(from: self, recipeID: ID)
     }
 }
 

--- a/HomeCafeRecipes/HomeCafeRecipes/Presentation/Tabbar/MainTabBarController.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Presentation/Tabbar/MainTabBarController.swift
@@ -81,12 +81,12 @@ class MainTabBarController: UITabBarController, UITabBarControllerDelegate {
         let alert = UIAlertController(title: "게시물 작성", message: "어떤 게시물을 작성하실 건가요?", preferredStyle: .actionSheet)
         alert.addAction(UIAlertAction(title: "Coffee", style: .default, handler: { [weak self] _ in
             guard let self else { return }
-            let addRecipeVC = self.router.createAddRecipeDependencies(recipeType: .coffee)
+            let addRecipeVC = router.makeAddRecipeViewController(recipeType: .coffee)
             self.navigationController?.pushViewController(addRecipeVC, animated: true)
         }))
         alert.addAction(UIAlertAction(title: "Dessert", style: .default, handler: { [weak self] _ in
             guard let self else { return }
-            let addRecipeVC = self.router.createAddRecipeDependencies(recipeType: .dessert)
+            let addRecipeVC = router.makeAddRecipeViewController(recipeType: .dessert)
             self.navigationController?.pushViewController(addRecipeVC, animated: true)
         }))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))

--- a/HomeCafeRecipes/HomeCafeRecipes/Presentation/Tabbar/MainTabBarController.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Presentation/Tabbar/MainTabBarController.swift
@@ -11,6 +11,16 @@ class MainTabBarController: UITabBarController, UITabBarControllerDelegate {
     
     private let addButton =  UIButton(type: .custom)
     private let buttonSize = CGSize(all: 64.0)
+    private let router =  Router()
+    
+    init(router: Router) {
+        self.router = router
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -33,23 +43,26 @@ class MainTabBarController: UITabBarController, UITabBarControllerDelegate {
     }
     
     private func setupTabBar() {
-        let baseneworkServie = BaseNetworkService()
-        let networkService = RecipeFetchServiceImpl(networkService: baseneworkServie)
-        let repository = FeedListRepositoryImpl(networkService: networkService)
-        let searchrepository = SearchFeedRepositoryImpl(networkService: networkService)
-        let fetchFeedListUseCase = FetchFeedListUseCaseImpl(repository: repository)
-        let searchFeedListUsecase = SearchFeedListUseCaseImpl(repository: searchrepository)
-        
-        let recipeListViewModel = RecipeListInteractor(fetchFeedListUseCase: fetchFeedListUseCase, searchFeedListUseCase: searchFeedListUsecase)
-        
-        let recipeListVC = RecipeListViewController(interactor: recipeListViewModel)
-        recipeListVC.tabBarItem = UITabBarItem(title: "Recipes", image: UIImage(systemName: "list.bullet"), tag: 0)
-        
-        let favoritesVC = UIViewController()
-        favoritesVC.view.backgroundColor = .white
-        favoritesVC.tabBarItem = UITabBarItem(title: "Favorites", image: UIImage(systemName: "bookmark"), tag: 1)
+        let recipeListVC = router.createRecipeListDependencies()
+        let favoritesVC = createFavoritesViewController()
+        recipeListVC.tabBarItem = UITabBarItem(
+            title: "Recipes",
+            image: UIImage(systemName: "list.bullet"),
+            tag: 0
+        )
+        favoritesVC.tabBarItem = UITabBarItem(
+            title: "Favorites",
+            image: UIImage(systemName: "bookmark"),
+            tag: 1
+        )
         
         viewControllers = [recipeListVC, favoritesVC]
+    }
+    
+    private func createFavoritesViewController() -> UIViewController {
+        let favoritesVC = UIViewController()
+        favoritesVC.view.backgroundColor = .white
+        return favoritesVC
     }
     
     private func setupActionButton() {
@@ -68,12 +81,12 @@ class MainTabBarController: UITabBarController, UITabBarControllerDelegate {
         let alert = UIAlertController(title: "게시물 작성", message: "어떤 게시물을 작성하실 건가요?", preferredStyle: .actionSheet)
         alert.addAction(UIAlertAction(title: "Coffee", style: .default, handler: { [weak self] _ in
             guard let self else { return }
-            let addRecipeVC = AddRecipeViewController(recipeType: .coffee)
+            let addRecipeVC = self.router.createAddRecipeDependencies(recipeType: .coffee)
             self.navigationController?.pushViewController(addRecipeVC, animated: true)
         }))
         alert.addAction(UIAlertAction(title: "Dessert", style: .default, handler: { [weak self] _ in
             guard let self else { return }
-            let addRecipeVC = AddRecipeViewController(recipeType: .dessert)
+            let addRecipeVC = self.router.createAddRecipeDependencies(recipeType: .dessert)
             self.navigationController?.pushViewController(addRecipeVC, animated: true)
         }))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))

--- a/HomeCafeRecipes/HomeCafeRecipes/Router/RecipeListRouter.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Router/RecipeListRouter.swift
@@ -19,7 +19,7 @@ class RecipeListRouterImpl: RecipeListRouter {
     }
     
     func navigateToRecipeDetail(from viewController: UIViewController, recipeID: Int) {
-        let detailVC = router.createRecipeDetailDependencies(recipeID: recipeID)
+        let detailVC = router.makeRecipeDetailViewController(recipeID: recipeID)
         router.push(detailVC, from: viewController, isAnimated: true, onNavigateBack: nil)
     }
 }

--- a/HomeCafeRecipes/HomeCafeRecipes/Router/RecipeListRouter.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Router/RecipeListRouter.swift
@@ -1,0 +1,25 @@
+//
+//  RecipeListRouter.swift
+//  HomeCafeRecipes
+//
+//  Created by 김건호 on 7/9/24.
+//
+
+import UIKit
+
+protocol RecipeListRouter {
+    func navigateToRecipeDetail(from viewController: UIViewController, recipeID: Int)
+}
+
+class RecipeListRouterImpl: RecipeListRouter {
+    private let router: Router
+    
+    init(router: Router) {
+        self.router = router
+    }
+    
+    func navigateToRecipeDetail(from viewController: UIViewController, recipeID: Int) {
+        let detailVC = router.createRecipeDetailDependencies(recipeID: recipeID)
+        router.push(detailVC, from: viewController, isAnimated: true, onNavigateBack: nil)
+    }
+}

--- a/HomeCafeRecipes/HomeCafeRecipes/Router/Router.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Router/Router.swift
@@ -1,0 +1,93 @@
+//
+//  Router.swift
+//  HomeCafeRecipes
+//
+//  Created by 김건호 on 7/9/24.
+//
+
+import UIKit
+
+public typealias NavigationBackClosure = () -> Void
+
+public protocol Drawable {
+    var viewController: UIViewController? { get }
+}
+
+public protocol RouterProtocol {
+    func push (
+        _ drawable: Drawable,
+        from viewController: UIViewController,
+        isAnimated: Bool,
+        onNavigateBack closure: NavigationBackClosure?
+    )
+}
+
+class Router: NSObject, RouterProtocol {
+    private var closures: [String: NavigationBackClosure] = [:]
+    
+    func push(
+        _ drawable: Drawable,
+        from viewController: UIViewController,
+        isAnimated: Bool,
+        onNavigateBack closure: NavigationBackClosure?
+    ) {
+        guard let targetViewController = drawable.viewController else {
+            return
+        }
+        
+        if let closure = closure {
+            closures.updateValue(closure, forKey: targetViewController.description)
+        }
+        viewController.navigationController?.pushViewController(targetViewController, animated: isAnimated)
+    }
+    
+    private func executeClosure(_ viewController: UIViewController) {
+        guard let closure = closures.removeValue(forKey: viewController.description) else { return }
+        closure()
+    }
+}
+
+extension Router {
+    func createRecipeListDependencies() -> RecipeListViewController {
+        let baseNetworkService = BaseNetworkService()
+        let recipeFetchService = RecipeFetchServiceImpl(networkService: baseNetworkService)
+        let feedListRepository = FeedListRepositoryImpl(networkService: recipeFetchService)
+        let searchFeedRepository = SearchFeedRepositoryImpl(networkService: recipeFetchService)
+        let fetchFeedListUseCase = FetchFeedListUseCaseImpl(repository: feedListRepository)
+        let searchFeedListUseCase = SearchFeedListUseCaseImpl(repository: searchFeedRepository)
+        let recipeListInteractor = RecipeListInteractorImpl(
+            fetchFeedListUseCase: fetchFeedListUseCase,
+            searchFeedListUseCase: searchFeedListUseCase
+        )
+        let recipeListRouter = RecipeListRouterImpl(router: self)
+        let recipeListVC = RecipeListViewController(
+            interactor: recipeListInteractor,
+            router: recipeListRouter
+        )
+        recipeListInteractor.delegate = recipeListVC
+        return recipeListVC
+    }
+    
+    func createAddRecipeDependencies(recipeType: RecipeType) -> AddRecipeViewController {
+        let baseNetworkService = BaseNetworkService()
+        let recipePostService = RecipePostServiceImpl(networkService: baseNetworkService)
+        let saveRepository = AddRecipeRepositoryImpl(recipePostService: recipePostService)
+        let saveRecipeUseCase = SaveRecipeUseCaseImpl(repository: saveRepository)
+        let addRecipeInteractor = AddRecipeInteractorImpl(saveRecipeUseCase: saveRecipeUseCase)
+        let addRecipeVC = AddRecipeViewController(recipeType: recipeType, addRecipeInteractor: addRecipeInteractor)
+        return addRecipeVC
+    }
+    
+    func createRecipeDetailDependencies(recipeID: Int) -> RecipeDetailViewController {
+        let baseNetworkService = BaseNetworkService()
+        let recipeDetailRepository = RecipeDetailRepositoryImpl(networkService: baseNetworkService)
+        let fetchRecipeDetailUseCase = FetchRecipeDetailUseCaseImpl(repository: recipeDetailRepository)
+        let detailInteractor = RecipeDetailInteractorImpl(
+            fetchRecipeDetailUseCase: fetchRecipeDetailUseCase,
+            recipeID: recipeID
+        )
+        let detailVC = RecipeDetailViewController(interactor: detailInteractor)
+        detailInteractor.delegate = detailVC
+        return detailVC
+    }
+}

--- a/HomeCafeRecipes/HomeCafeRecipes/Router/Router.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Router/Router.swift
@@ -48,7 +48,7 @@ class Router: NSObject, RouterProtocol {
 }
 
 extension Router {
-    func createRecipeListDependencies() -> RecipeListViewController {
+    func makeRecipeListViewController() -> RecipeListViewController {
         let recipeListInteractor = RecipeListInteractorImpl(
             fetchFeedListUseCase: FetchFeedListUseCaseImpl(
                 repository: FeedListRepositoryImpl(
@@ -74,7 +74,7 @@ extension Router {
         return recipeListVC
     }
     
-    func createAddRecipeDependencies(recipeType: RecipeType) -> AddRecipeViewController {
+    func makeAddRecipeViewController(recipeType: RecipeType) -> AddRecipeViewController {
         let addRecipeInteractor = AddRecipeInteractorImpl(
             saveRecipeUseCase: AddRecipeUseCaseImpl(
                 repository: AddRecipeRepositoryImpl(
@@ -92,7 +92,7 @@ extension Router {
         return addRecipeVC
     }
     
-    func createRecipeDetailDependencies(recipeID: Int) -> RecipeDetailViewController {
+    func makeRecipeDetailViewController(recipeID: Int) -> RecipeDetailViewController {
         let detailInteractor = RecipeDetailInteractorImpl(
             fetchRecipeDetailUseCase: FetchRecipeDetailUseCaseImpl(
                 repository: RecipeDetailRepositoryImpl(

--- a/HomeCafeRecipes/HomeCafeRecipes/Router/Router.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Router/Router.swift
@@ -49,15 +49,21 @@ class Router: NSObject, RouterProtocol {
 
 extension Router {
     func createRecipeListDependencies() -> RecipeListViewController {
-        let baseNetworkService = BaseNetworkService()
-        let recipeFetchService = RecipeFetchServiceImpl(networkService: baseNetworkService)
-        let feedListRepository = FeedListRepositoryImpl(networkService: recipeFetchService)
-        let searchFeedRepository = SearchFeedRepositoryImpl(networkService: recipeFetchService)
-        let fetchFeedListUseCase = FetchFeedListUseCaseImpl(repository: feedListRepository)
-        let searchFeedListUseCase = SearchFeedListUseCaseImpl(repository: searchFeedRepository)
         let recipeListInteractor = RecipeListInteractorImpl(
-            fetchFeedListUseCase: fetchFeedListUseCase,
-            searchFeedListUseCase: searchFeedListUseCase
+            fetchFeedListUseCase: FetchFeedListUseCaseImpl(
+                repository: FeedListRepositoryImpl(
+                    networkService: RecipeFetchServiceImpl(
+                        networkService: BaseNetworkService()
+                    )
+                )
+            ),
+            searchFeedListUseCase: SearchFeedListUseCaseImpl(
+                repository: SearchFeedRepositoryImpl(
+                    networkService: RecipeFetchServiceImpl(
+                        networkService: BaseNetworkService()
+                    )
+                )
+            )
         )
         let recipeListRouter = RecipeListRouterImpl(router: self)
         let recipeListVC = RecipeListViewController(
@@ -69,21 +75,30 @@ extension Router {
     }
     
     func createAddRecipeDependencies(recipeType: RecipeType) -> AddRecipeViewController {
-        let baseNetworkService = BaseNetworkService()
-        let recipePostService = RecipePostServiceImpl(networkService: baseNetworkService)
-        let saveRepository = AddRecipeRepositoryImpl(recipePostService: recipePostService)
-        let saveRecipeUseCase = SaveRecipeUseCaseImpl(repository: saveRepository)
-        let addRecipeInteractor = AddRecipeInteractorImpl(saveRecipeUseCase: saveRecipeUseCase)
-        let addRecipeVC = AddRecipeViewController(recipeType: recipeType, addRecipeInteractor: addRecipeInteractor)
+        let addRecipeInteractor = AddRecipeInteractorImpl(
+            saveRecipeUseCase: AddRecipeUseCaseImpl(
+                repository: AddRecipeRepositoryImpl(
+                    recipePostService: RecipePostServiceImpl(
+                        networkService: BaseNetworkService()
+                    )
+                )
+            )
+        )
+        let addRecipeVC = AddRecipeViewController(
+            recipeType: recipeType,
+            addRecipeInteractor: addRecipeInteractor
+        )
+        addRecipeInteractor.delegate = addRecipeVC
         return addRecipeVC
     }
     
     func createRecipeDetailDependencies(recipeID: Int) -> RecipeDetailViewController {
-        let baseNetworkService = BaseNetworkService()
-        let recipeDetailRepository = RecipeDetailRepositoryImpl(networkService: baseNetworkService)
-        let fetchRecipeDetailUseCase = FetchRecipeDetailUseCaseImpl(repository: recipeDetailRepository)
         let detailInteractor = RecipeDetailInteractorImpl(
-            fetchRecipeDetailUseCase: fetchRecipeDetailUseCase,
+            fetchRecipeDetailUseCase: FetchRecipeDetailUseCaseImpl(
+                repository: RecipeDetailRepositoryImpl(
+                    networkService: BaseNetworkService()
+                )
+            ),
             recipeID: recipeID
         )
         let detailVC = RecipeDetailViewController(interactor: detailInteractor)

--- a/HomeCafeRecipes/HomeCafeRecipes/SceneDelegate.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/SceneDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
-    
+    var router: Router?
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
@@ -18,8 +18,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let mainViewController = ViewController()
-        let navigationController = UINavigationController(rootViewController : mainViewController)        
+        router = Router()
+        guard let router else { return }
+        
+        let tabBarController = MainTabBarController(router: router)
+        let navigationController = UINavigationController(rootViewController: tabBarController)
+        navigationController.isNavigationBarHidden = true
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }


### PR DESCRIPTION
#### 화면 이동, 의존성 주입을 다른 곳에서 관리하기 위해 라우터를 도입했습니다.
- 각각 화면의 의존성을 Router에서 주입시켜 줍니다.
- 화면의 push를 Router에서 적용해서 관리 합니다.
- Drawable 프로토콜은 화면 전환에 사용될 수 있는 뷰 컨트롤러를 추상화합니다
- SceneDelegate에서 Router 인스턴스를 생성하고, 이를 통해 초기 화면을 설정합니다.
- MainTabBarController를 Router를 통해 초기화하여 의존성을 주입받도록 변경했습니다.