### PR TITLE
레시피 리스트 fetch 데이터 관련 로직 수정

### DIFF
--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/RecipeDTO.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/RecipeDTO.swift
@@ -9,25 +9,19 @@ import Foundation
 
 struct RecipeDTO: Decodable {
     
-    let id: Int
-    let type: String
+    let ID: Int
     let name: String
-    let description: String
     let likesCount: Int
-    let createdAt: String
     let writer: UserDTO
-    let imageUrls: [RecipeImageDTO]
+    let recipeImageUrl: String
     let isLikedByCurrentUser: Bool
         
     enum CodingKeys: String, CodingKey {
-        case id = "recipeId"
-        case type = "recipeType"
+        case ID = "recipeId"
         case name = "recipeName"
-        case description = "recipeDescription"
         case likesCount = "recipeLikesCnt"
-        case createdAt = "createdAt"
         case writer = "writer"
-        case imageUrls = "recipeImgUrls"
+        case recipeImageUrl = "recipeImageUrl"
         case isLikedByCurrentUser = "isLiked"
     }
 }
@@ -35,15 +29,15 @@ struct RecipeDTO: Decodable {
 extension RecipeDTO {
     func toDomain() -> Recipe {
         return Recipe(
-            id: id,
-            type: RecipeType(rawValue: type) ?? .coffee,
+            id: ID,
+            type: .coffee, // MARK: 임시 값 커피로 설정
             name: name,
-            description: description,
+            description: "",
             writer: writer.toDomain(),
-            imageUrls: imageUrls.map { $0.recipeImageUrl },
+            imageUrls: [recipeImageUrl],
             isLikedByCurrentUser: isLikedByCurrentUser,
             likeCount: likesCount,
-            createdAt: DateFormatter.iso8601.date(from: createdAt) ?? Date()
+            createdAt: Date()
         )
     }
 }

--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/RecipeDetailDTO.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/RecipeDetailDTO.swift
@@ -8,20 +8,17 @@
 import Foundation
 
 struct RecipeDetailDTO: Decodable {
-    
     let id: Int
-    let type: String
     let name: String
     let description: String
     let likesCount: Int
     let createdAt: String
     let writer: UserDTO
-    let imageUrls: [RecipeImageDTO]
+    let imageUrls: [String] // 배열로 수신
     let isLikedByCurrentUser: Bool
         
     enum CodingKeys: String, CodingKey {
         case id = "recipeId"
-        case type = "recipeType"
         case name = "recipeName"
         case description = "recipeDescription"
         case likesCount = "recipeLikesCnt"
@@ -35,12 +32,12 @@ struct RecipeDetailDTO: Decodable {
 extension RecipeDetailDTO {
     func toDomain() -> Recipe {
         return Recipe(
-            id: id,
-            type: RecipeType(rawValue: type) ?? .coffee,
+            id: id, 
+            type: .coffee,
             name: name,
             description: description,
             writer: writer.toDomain(),
-            imageUrls: imageUrls.map { $0.recipeImageUrl },
+            imageUrls: imageUrls,
             isLikedByCurrentUser: isLikedByCurrentUser,
             likeCount: likesCount,
             createdAt: DateFormatter.iso8601.date(from: createdAt) ?? Date()

--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/RecipePageDTO.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/RecipePageDTO.swift
@@ -10,11 +10,13 @@ import Foundation
 struct RecipePageDTO: Decodable {
     let totalPageNumber: Int
     let pageNumber: Int
+    let lastBoundaryId: Int
     let recipes: [RecipeDTO]
 
     private enum CodingKeys: String, CodingKey {
         case totalPageNumber = "totalPageNumber"
         case pageNumber = "pageNumber"
+        case lastBoundaryId = "lastBoundaryId"
         case recipes = "recipes"
     }
 }

--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/RecipeUploadResponseDTO.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/RecipeUploadResponseDTO.swift
@@ -16,7 +16,7 @@ struct RecipeUploadResponseDTO: Decodable {
     let likesCount: Int
     let createdAt: String
     let writer: UserDTO
-    let imageUrls: [RecipeImageDTO]
+    let imageUrls: [String]
     let isLikedByCurrentUser: Bool
         
     enum CodingKeys: String, CodingKey {
@@ -41,7 +41,7 @@ extension RecipeUploadResponseDTO {
             name: name,
             description: description,
             writer: writer.toDomain(),
-            imageUrls: imageUrls.map { $0.recipeImageUrl },
+            imageUrls: imageUrls,
             isLikedByCurrentUser: isLikedByCurrentUser,
             likeCount: likesCount,
             createdAt: DateFormatter.iso8601.date(from: createdAt) ?? Date()

--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Repositories/FeedListRepository.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Repositories/FeedListRepository.swift
@@ -8,7 +8,7 @@
 import RxSwift
 
 protocol FeedListRepository {
-    func fetchRecipes(pageNumber: Int) -> Single<[Recipe]>
+    func fetchRecipes(currentPage: Int, targetPage: Int, boundaryID: Int) -> Single<[Recipe]>
 }
 
 class FeedListRepositoryImpl: FeedListRepository {
@@ -18,7 +18,7 @@ class FeedListRepositoryImpl: FeedListRepository {
         self.networkService = networkService
     }
 
-    func fetchRecipes(pageNumber: Int) -> Single<[Recipe]> {
-        return networkService.fetchRecipes(pageNumber: pageNumber)
+    func fetchRecipes(currentPage: Int, targetPage: Int, boundaryID: Int) -> Single<[Recipe]> {
+        return networkService.fetchRecipes(currentPage: currentPage, targetPage: targetPage, boundaryID: boundaryID)
     }
 }

--- a/HomeCafeRecipes/HomeCafeRecipes/Domain/UseCases/FetchFeedListUseCase.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Domain/UseCases/FetchFeedListUseCase.swift
@@ -8,7 +8,7 @@
 import RxSwift
 
 protocol FetchFeedListUseCase {
-    func execute(pageNumber: Int) -> Single<Result<[Recipe], Error>>
+    func execute(currentPage: Int, targetPage: Int, boundaryID: Int) -> Single<Result<[Recipe], Error>>
 }
 
 class FetchFeedListUseCaseImpl: FetchFeedListUseCase {
@@ -18,13 +18,17 @@ class FetchFeedListUseCaseImpl: FetchFeedListUseCase {
         self.repository = repository
     }
     
-    func execute(pageNumber: Int) -> Single<Result<[Recipe], Error>> {
-        return repository.fetchRecipes(pageNumber: pageNumber)
-            .map { recipes in                
-                return .success(recipes)
-            }
-            .catch { error in
-                return .just(.failure(error))
-            }
+    func execute(currentPage: Int, targetPage: Int, boundaryID: Int) -> Single<Result<[Recipe], Error>> {
+        return repository.fetchRecipes(
+            currentPage: currentPage,
+            targetPage: targetPage,
+            boundaryID: boundaryID
+        )
+        .map { recipes in
+            return .success(recipes)
+        }
+        .catch { error in
+            return .just(.failure(error))
+        }
     }
 }


### PR DESCRIPTION
### PR 개요
레시피 리스트 fetch 데이터 관련 로직 수정

---

### 주요 변경 사항
1.	데이터 네이밍과 형식 수정
	•	recipeImageUrl의 형식을 배열에서 단일 URL로 변경했습니다
	•	네트워크 통신에서 받아오는 Recipe 데이터를 DTO에 맞게 네이밍 및 형식 정리했습니다

2.	레시피 리스트 fetch 시 필요한 파라미터 추가 및 선언
	•	currentPage, targetPage, boundaryID를 네트워크 요청에 추가하여 효율적으로 데이터를 가져오도록 수정했습니다
	•	새로운 파라미터를 처리하기 위해 FetchFeedListUseCase 및 관련 메서드에 수정 반영했습니다..

3.	레시피 리스트 fetch 로직 수정
	•	boundaryID 값이 현재 페이지의 최대 recipeId를 기준으로 설정되도록 구현했습니다.

4.	Repository의 파라미터 수정
	•	레시피 데이터를 불러오는 Repository 계층에서 새로운 네트워크 요청 형식에 맞게 파라미터 변경.
	•	기존 pageNumber 단일 값 요청을 currentPage, targetPage, boundaryID로 대체.
---
