### PR TITLE
레시피 검색 부분 서버 리팩토링으로 인한 네트워크 로직 수정

### DIFF
--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Network/RecipeFetchService.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Network/RecipeFetchService.swift
@@ -27,16 +27,35 @@ class RecipeFetchServiceImpl: RecipeFetchService {
         return URLComponents?.url
     }
     
+    private func makeQueryItems(
+        currentPage: Int,
+        targetPage: Int,
+        boundaryID: Int,
+        keyword: String? = nil
+    ) -> [URLQueryItem] {
+        var queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "currentPage", value: String(currentPage)),
+            URLQueryItem(name: "targetPage", value: String(targetPage)),
+            URLQueryItem(name: "boundaryId", value: String(boundaryID))
+        ]
+        
+        if let keyword = keyword, !keyword.isEmpty {
+            queryItems.append(URLQueryItem(name: "keyword", value: keyword))
+        }
+        
+        return queryItems
+    }
+    
     func fetchRecipes(
         currentPage: Int,
         targetPage: Int,
         boundaryID: Int
     ) -> Single<[Recipe]> {
-        let queryItems = [
-            URLQueryItem(name: "currentPage", value: String(currentPage)),
-            URLQueryItem(name: "targetPage", value: String(targetPage)),
-            URLQueryItem(name: "boundaryId", value: String(boundaryID))
-        ]
+        let queryItems = makeQueryItems(
+            currentPage: currentPage,
+            targetPage: targetPage,
+            boundaryID: boundaryID
+        )
         
         guard let URL = makeURL(endpoint: "recipes", queryItems: queryItems) else {
             return Single.error(NSError(

--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Repositories/SearchFeedListRepository.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Repositories/SearchFeedListRepository.swift
@@ -8,18 +8,28 @@
 import RxSwift
 
 protocol SearchFeedListRepository {
-    func searchRecipes(title: String, pageNumber: Int) -> Single<[Recipe]>
+    func searchRecipes(title: String, currentPage: Int, targetPage: Int, boundaryID: Int) -> Single<[Recipe]>
 }
 
 class SearchFeedRepositoryImpl: SearchFeedListRepository {
-            
+    
     private let networkService: RecipeFetchService
     
     init(networkService: RecipeFetchService) {
         self.networkService = networkService
     }
     
-    func searchRecipes(title: String,pageNumber: Int) -> Single<[Recipe]> {
-        return networkService.searchRecipes(title: title, pageNumber: pageNumber)
+    func searchRecipes(
+        title: String,
+        currentPage: Int,
+        targetPage: Int,
+        boundaryID: Int
+    ) -> Single<[Recipe]> {
+        return networkService.searchRecipes(
+            title: title,
+            currentPage: currentPage,
+            targetPage: targetPage,
+            boundaryID: boundaryID
+        )
     }
 }

--- a/HomeCafeRecipes/HomeCafeRecipes/Domain/UseCases/SearchFeedUseCase.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Domain/UseCases/SearchFeedUseCase.swift
@@ -8,7 +8,7 @@
 import RxSwift
 
 protocol SearchFeedListUseCase {
-    func execute(title: String,pageNumber: Int) -> Single<Result<[Recipe], Error>>
+    func execute(title: String, currentPage: Int, targetPage: Int, boundaryID: Int) -> Single<Result<[Recipe], Error>>
 }
 
 class SearchFeedListUseCaseImpl: SearchFeedListUseCase {
@@ -17,14 +17,24 @@ class SearchFeedListUseCaseImpl: SearchFeedListUseCase {
     init(repository: SearchFeedListRepository) {
         self.repository = repository
     }
-
-    func execute(title: String,pageNumber: Int) -> Single<Result<[Recipe], Error>> {
-        return repository.searchRecipes(title: title,pageNumber: pageNumber)
-            .map { recipes in
-                return .success(recipes)
-            }
-            .catch { error in
-                return .just(.failure(error))
-            }
+    
+    func execute(
+        title: String,
+        currentPage: Int,
+        targetPage: Int,
+        boundaryID: Int
+    ) -> Single<Result<[Recipe], Error>> {
+        return repository.searchRecipes(
+            title: title,
+            currentPage: currentPage,
+            targetPage: targetPage,
+            boundaryID: boundaryID
+        )
+        .map { recipes in
+            return .success(recipes)
+        }
+        .catch { error in
+            return .just(.failure(error))
+        }
     }
 }


### PR DESCRIPTION
### PR 개요
레시피 검색 부분 서버 리팩토링으로 인한 네트워크 로직 수정

---
### 주요 변경 사항

1. 쿼리 생성 메서드 추가 및 적용
   - makeQueryItems 메서드를 도입하여 네트워크 요청 시 반복되는 쿼리 생성 로직을 재사용 가능하도록 변경.
   - 각 네트워크 요청 메서드에서 동적으로 쿼리를 생성하도록 수정.

2. 레시피 검색 요청 개선
   - 네트워크 요청 시 currentPage, targetPage, boundaryID를 추가하여 데이터 효율성을 개선.
   - 새로운 요청 형식에 맞게 FetchFeedListUseCase 및 관련 메서드를 수정하여 대응.

3. 레시피 리스트 Fetch 로직 수정
   -  boundaryID 값이 현재 페이지의 **최대 recipeId**를 기준으로 설정되도록 구현.
   - 검색 중 동일한 키워드 요청 시 중복 boundary 값 처리를 방지.

4. Repository 계층 로직 수정
   - Repository 계층의 파라미터를 기존 단일 pageNumber 요청에서 currentPage, targetPage, boundaryID로 변경.
   - 새로운 파라미터 처리 로직을 추가하여 네트워크 요청 형식과 일치하도록 수정.

---
