### PR TITLE
레시피 상세페이지부분 서버 리팩토링으로 인한 DTO 수정

### DIFF
--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/RecipeDetailDTO.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/RecipeDetailDTO.swift
@@ -14,9 +14,9 @@ struct RecipeDetailDTO: Decodable {
     let likesCount: Int
     let createdAt: String
     let writer: UserDTO
-    let imageUrls: [String] // 배열로 수신
+    let imageUrls: [RecipeImageDTO]
     let isLikedByCurrentUser: Bool
-        
+    
     enum CodingKeys: String, CodingKey {
         case id = "recipeId"
         case name = "recipeName"
@@ -24,7 +24,7 @@ struct RecipeDetailDTO: Decodable {
         case likesCount = "recipeLikesCnt"
         case createdAt = "createdAt"
         case writer = "writer"
-        case imageUrls = "recipeImgUrls"
+        case imageUrls = "recipeImages"
         case isLikedByCurrentUser = "isLiked"
     }
 }
@@ -32,12 +32,12 @@ struct RecipeDetailDTO: Decodable {
 extension RecipeDetailDTO {
     func toDomain() -> Recipe {
         return Recipe(
-            id: id, 
+            id: id,
             type: .coffee,
             name: name,
             description: description,
             writer: writer.toDomain(),
-            imageUrls: imageUrls,
+            imageUrls: imageUrls.map{ $0.recipeImageUrl },
             isLikedByCurrentUser: isLikedByCurrentUser,
             likeCount: likesCount,
             createdAt: DateFormatter.iso8601.date(from: createdAt) ?? Date()

--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/RecipeImageDTO.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/RecipeImageDTO.swift
@@ -12,7 +12,7 @@ struct RecipeImageDTO: Decodable {
     let recipeImageUrl: String
     
     private enum CodingKeys: String, CodingKey {
-        case recipeImageID = "recipeImgId"
-        case recipeImageUrl = "recipeImgUrl"
+        case recipeImageID = "recipeImageId"
+        case recipeImageUrl = "recipeImageUrl"
     }
 }

--- a/HomeCafeRecipes/HomeCafeRecipes/Presentation/Feed/View/RecipeDetailViewController.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Presentation/Feed/View/RecipeDetailViewController.swift
@@ -90,8 +90,7 @@ extension RecipeDetailViewController: RecipeDetailViewDelegate {
             print("Recipe ID is missing")
             return
         }
-        router.presentCommentViewModally(from: self, recipeID: recipeID)
-        print(recipeID)
+        router.presentCommentViewModally(from: self, recipeID: recipeID)        
     }
     
     func didTapBookmarkButton() {


### PR DESCRIPTION
### PR 개요
레시피 상세페이지부분 서버 리팩토링으로 인한 DTO 수정

---
### 주요 변경 사항

1. DTO의 이미지 네이밍 수정
   - 이미지의 네이밍을 recipeImgUrls에서 recipeImages로 변경되어 수정
   - recipeImageUrl의 recipeImageId, recipeImgUrl를 recipeImageId, recipeImageUrl로 수정

2. 불필요한 print문 삭제

---
