### PR TITLE
리팩토링으로 인한 수정된 내용 테스트코드에 반영

### DIFF
--- a/HomeCafeRecipes/HomeCafeRecipes/Domain/Entities/User.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Domain/Entities/User.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct User {
+struct User: Equatable {
     let id: Int
     let profileImage: String
     let nickname: String

--- a/HomeCafeRecipes/HomeCafeRecipesTests/FetchFeedListUseCaseTests.swift
+++ b/HomeCafeRecipes/HomeCafeRecipesTests/FetchFeedListUseCaseTests.swift
@@ -22,7 +22,11 @@ final class FetchFeedListUseCaseTests: XCTestCase {
         var fetchRecipeListCallCount: Int = 0
         var fetchRecipeListStub: Single<[Recipe]> = .just([Recipe.dummyRecipe()])
         
-        func fetchRecipes(pageNumber: Int) -> Single<[Recipe]> {
+        func fetchRecipes(
+            currentPage: Int,
+            targetPage: Int,
+            boundaryID: Int
+        ) -> Single<[Recipe]> {
             fetchRecipeListCallCount += 1
             return fetchRecipeListStub
         }
@@ -49,9 +53,13 @@ extension FetchFeedListUseCaseTests {
         
         // When
         
-        usecase.execute(pageNumber: 0)
-            .subscribe()
-            .disposed(by: disposeBag)
+        usecase.execute(
+            currentPage: 0,
+            targetPage: 0,
+            boundaryID: 0
+        )
+        .subscribe()
+        .disposed(by: disposeBag)
         
         // Then
         
@@ -66,20 +74,24 @@ extension FetchFeedListUseCaseTests {
         
         // When
         
-        usecase.execute(pageNumber: 0)
-            .subscribe(onSuccess:{ result in
-                if case .success(let fetchedRecipes) = result {
-                    XCTAssertTrue(TestUtils.areRecipesEqual(fetchedRecipes, recipe))
-                    expectation.fulfill()
-                } else {
-                    XCTFail("Expected success but got failure")
-                }
-                
-            }, onFailure: { error in
-                XCTFail("Expected success but got error: \(error)")
-                
-            })
-            .disposed(by: disposeBag)
+        usecase.execute(
+            currentPage: 0,
+            targetPage: 0,
+            boundaryID: 0
+        )
+        .subscribe(onSuccess:{ result in
+            if case .success(let fetchedRecipes) = result {
+                XCTAssertTrue(TestUtils.areRecipesEqual(fetchedRecipes, recipe))
+                expectation.fulfill()
+            } else {
+                XCTFail("Expected success but got failure")
+            }
+            
+        }, onFailure: { error in
+            XCTFail("Expected success but got error: \(error)")
+            
+        })
+        .disposed(by: disposeBag)
         
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(fetchRecipeListRepository.fetchRecipeListCallCount, 1)
@@ -93,21 +105,25 @@ extension FetchFeedListUseCaseTests {
         let expectation = self.expectation(description: "Fetch Recipes Failure")
         
         // When
-        usecase.execute(pageNumber: 0)
-            .subscribe(onSuccess: { result in
-                if case .failure(let receivedError as NSError) = result {
-                    // Then
-                    
-                    XCTAssertEqual(receivedError.domain, error.domain)
-                    XCTAssertEqual(receivedError.code, error.code)
-                    expectation.fulfill()
-                } else {
-                    XCTFail("Expected failure but got success")
-                }
-            }, onFailure: { error in
-                XCTFail("Expected failure but got error: \(error)")
-            })
-            .disposed(by: disposeBag)
+        usecase.execute(
+            currentPage: 0,
+            targetPage: 0,
+            boundaryID: 0
+        )
+        .subscribe(onSuccess: { result in
+            if case .failure(let receivedError as NSError) = result {
+                // Then
+                
+                XCTAssertEqual(receivedError.domain, error.domain)
+                XCTAssertEqual(receivedError.code, error.code)
+                expectation.fulfill()
+            } else {
+                XCTFail("Expected failure but got success")
+            }
+        }, onFailure: { error in
+            XCTFail("Expected failure but got error: \(error)")
+        })
+        .disposed(by: disposeBag)
         
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(fetchRecipeListRepository.fetchRecipeListCallCount, 1)

--- a/HomeCafeRecipes/HomeCafeRecipesTests/RecipeListInteractorTests.swift
+++ b/HomeCafeRecipes/HomeCafeRecipesTests/RecipeListInteractorTests.swift
@@ -22,8 +22,20 @@ final class RecipeListInteractorTests: XCTestCase {
     
     final class FetchFeedListUseCaseMock: FetchFeedListUseCase {
         var executeCallCount: Int = 0
-        var executeStub: Single<Result<[Recipe], Error>> = .just(.failure(NSError(domain: "Test", code: -1, userInfo: nil)))
-        func execute(pageNumber: Int) -> Single<Result<[Recipe], Error>> {
+        var executeStub: Single<Result<[Recipe], Error>> = .just(
+            .failure(
+                NSError(
+                    domain: "Test",
+                    code: -1,
+                    userInfo: nil
+                )
+            )
+        )
+        func execute(
+            currentPage: Int,
+            targetPage: Int,
+            boundaryID: Int
+        ) -> Single<Result<[Recipe], Error>> {
             executeCallCount += 1
             return executeStub
         }
@@ -31,9 +43,22 @@ final class RecipeListInteractorTests: XCTestCase {
     
     final class SearchFeedListUseCaseMock: SearchFeedListUseCase {
         var executeCallCount: Int = 0
-        var executeStub: Single<Result<[Recipe], Error>> = .just(.failure(NSError(domain: "Test", code: -1, userInfo: nil)))
-
-        func execute(title: String, pageNumber: Int) -> Single<Result<[Recipe], Error>> {
+        var executeStub: Single<Result<[Recipe], Error>> = .just(
+            .failure(
+                NSError(
+                    domain: "Test",
+                    code: -1,
+                    userInfo: nil
+                )
+            )
+        )
+        
+        func execute(
+            title: String,
+            currentPage: Int,
+            targetPage: Int,
+            boundaryID: Int
+        ) -> Single<Result<[Recipe], Error>> {
             executeCallCount += 1
             return executeStub
         }
@@ -49,7 +74,7 @@ final class RecipeListInteractorTests: XCTestCase {
             fetchedCallCount += 1
             fetchedRecipeResult = result
         }
-
+        
         func showRecipeDetail(ID: Int) {
             showRecipeDetailCallCount += 1
             receivedShowRecipeDetailID = ID
@@ -157,7 +182,7 @@ extension RecipeListInteractorTests {
         // Given
         let interactor = createInteractor()
         let initialRecipes = [Recipe.dummyRecipe()]
-        let nextPageRecipes = [Recipe.dummyRecipe(id: 2)]        
+        let nextPageRecipes = [Recipe.dummyRecipe(id: 2)]
         fetchFeedListUseCase.executeStub = .just(.success(initialRecipes))
         interactor.viewDidLoad()
         fetchFeedListUseCase.executeStub = .just(.success(nextPageRecipes))

--- a/HomeCafeRecipes/HomeCafeRecipesTests/RecipeListInteractorTests.swift
+++ b/HomeCafeRecipes/HomeCafeRecipesTests/RecipeListInteractorTests.swift
@@ -134,6 +134,26 @@ extension RecipeListInteractorTests {
         }
     }
     
+    func test_boundaryID가_최대값으로_설정됩니다() {
+        // Given
+        let interactor = createInteractor()
+        let recipes = [
+            Recipe.dummyRecipe(id: 1),
+            Recipe.dummyRecipe(id: 3),
+            Recipe.dummyRecipe(id: 2)
+        ]
+        
+        fetchFeedListUseCase.executeStub = .just(.success(recipes))
+        
+        // When
+        interactor.viewDidLoad()
+        
+        // Then
+        XCTAssertEqual(fetchFeedListUseCase.executeCallCount, 1)
+        XCTAssertEqual(delegate.fetchedCallCount, 1)
+        XCTAssertEqual(recipes.map( {$0.id} ).max(), 3)
+    }
+    
     func test_FetchFeedListUseCase의_실패응답이오면_Delegate로_실패를_전달합니다() {
         
         // Given

--- a/HomeCafeRecipes/HomeCafeRecipesTests/SearchFeedListUseCaseTests.swift
+++ b/HomeCafeRecipes/HomeCafeRecipesTests/SearchFeedListUseCaseTests.swift
@@ -22,7 +22,9 @@ final class SearchFeedListUseCaseTests: XCTestCase {
         var searchRecipeListStub: Single<[Recipe]> = .just([Recipe.dummyRecipe()])
         func searchRecipes(
             title: String,
-            pageNumber: Int
+            currentPage: Int,
+            targetPage: Int,
+            boundaryID: Int
         ) -> Single<[Recipe]>
         {
             searchRecipeListCallCount += 1
@@ -50,7 +52,9 @@ final class SearchFeedListUseCaseTests: XCTestCase {
         
         usecase.execute(
             title: "",
-            pageNumber: 0
+            currentPage: 0,
+            targetPage: 0,
+            boundaryID: 0
         )
         .subscribe()
         .disposed(by: disposeBag)
@@ -70,7 +74,9 @@ final class SearchFeedListUseCaseTests: XCTestCase {
         // When
         usecase.execute(
             title: "Test Recipe",
-            pageNumber: 1
+            currentPage: 0,
+            targetPage: 0,
+            boundaryID: 0
         )
         .subscribe(onSuccess: { result in
             switch result {
@@ -98,20 +104,24 @@ final class SearchFeedListUseCaseTests: XCTestCase {
         let expectation = self.expectation(description: "Search Recipes Failure")
         
         // When
-        usecase.execute(title: "Test Recipe", pageNumber: 1)
-            .subscribe(onSuccess: { result in
-                switch result {
-                case .success:
-                    XCTFail("Expected failure but got success")
-                case .failure(let receivedError as NSError):
-                    XCTAssertEqual(receivedError.domain, error.domain)
-                    XCTAssertEqual(receivedError.code, error.code)
-                    expectation.fulfill()
-                }
-            }, onFailure: { error in
-                XCTFail("Expected failure but got error: \(error)")
-            })
-            .disposed(by: disposeBag)
+        usecase.execute(title: "Test Recipe",
+                        currentPage: 0,
+                        targetPage: 0,
+                        boundaryID: 0
+        )
+        .subscribe(onSuccess: { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure but got success")
+            case .failure(let receivedError as NSError):
+                XCTAssertEqual(receivedError.domain, error.domain)
+                XCTAssertEqual(receivedError.code, error.code)
+                expectation.fulfill()
+            }
+        }, onFailure: { error in
+            XCTFail("Expected failure but got error: \(error)")
+        })
+        .disposed(by: disposeBag)
         
         wait(for: [expectation], timeout: 1.0)
     }


### PR DESCRIPTION
### PR 개요
서버 리팩토링으로 인한 비즈니스 로직수정된 부분 테스트코드에 반영

---
### 주요 변경 사항

1. FetchFeedListUseCaseTests, RecipeListInteractorTests, SearchFeedListUseCaseTests에 각각 수정된 파라미터 반영
   - 각각의 메서드의 변경된 파라미터를 적용하였습니다.

2. BoundaryID 로직 테스트
   - 성공적으로 fetch에 성공했을경우 레시피ID 값이 가장 큰 값이 BoundaryID가 되는지 확인하는 테스트 케이스를 추가하였습니다.

3. User에 Equatable 선언 추가로 TestUtils 오류 해결
---
