### PR TITLE
로그인 로직 리팩토링 및 테스트 코드 추가

### DIFF
--- a/HomeCafeRecipes/HomeCafeRecipes.xcodeproj/project.pbxproj
+++ b/HomeCafeRecipes/HomeCafeRecipes.xcodeproj/project.pbxproj
@@ -48,7 +48,6 @@
 		1D3523AC2D37E8BD007DD505 /* LoginResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3523AB2D37E8BD007DD505 /* LoginResponseDTO.swift */; };
 		1D3523B02D389B89007DD505 /* KeychainRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3523AF2D389B89007DD505 /* KeychainRepository.swift */; };
 		1D3523B22D390346007DD505 /* TokenSaveUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3523B12D390346007DD505 /* TokenSaveUseCase.swift */; };
-		1D3523B42D391C01007DD505 /* LoginInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3523B32D391C01007DD505 /* LoginInteractorTests.swift */; };
 		1D3972682C44185B00495014 /* RecipeListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3972672C44185B00495014 /* RecipeListMapper.swift */; };
 		1D39726C2C458CE100495014 /* MultipartFormDataRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D39726B2C458CE100495014 /* MultipartFormDataRequest.swift */; };
 		1D39729C2C45905700495014 /* MultipartFormDataRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D39726B2C458CE100495014 /* MultipartFormDataRequest.swift */; };
@@ -117,6 +116,17 @@
 		1D93B9992CA26EB80094277F /* LoginUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D93B9982CA26EB80094277F /* LoginUseCaseTests.swift */; };
 		1D95A0A62C37C79500F09077 /* RecipeDetailError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D95A0A52C37C79500F09077 /* RecipeDetailError.swift */; };
 		1D96FDAA2C7F55E600EFC657 /* LoginInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D96FDA92C7F55E600EFC657 /* LoginInteractor.swift */; };
+		1DAD9EAB2D39F934001E9F49 /* LoginInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAD9EAA2D39F934001E9F49 /* LoginInteractorTests.swift */; };
+		1DAD9EAC2D39FB43001E9F49 /* TokenSaveUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3523B12D390346007DD505 /* TokenSaveUseCase.swift */; };
+		1DAD9EAD2D39FB49001E9F49 /* LoginInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D96FDA92C7F55E600EFC657 /* LoginInteractor.swift */; };
+		1DAD9EAE2D3A3D98001E9F49 /* LoginResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3523AB2D37E8BD007DD505 /* LoginResponseDTO.swift */; };
+		1DAD9EAF2D3A3DA5001E9F49 /* KeychainRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3523AF2D389B89007DD505 /* KeychainRepository.swift */; };
+		1DAD9EB02D3A3DC3001E9F49 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF0D1A82C7DF9AA00E2C94C /* LoginViewModel.swift */; };
+		1DAD9EB22D3A61AA001E9F49 /* ReissueTokenUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAD9EB12D3A61AA001E9F49 /* ReissueTokenUseCase.swift */; };
+		1DAD9EB42D3A6223001E9F49 /* ReissueTokenRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAD9EB32D3A6223001E9F49 /* ReissueTokenRepository.swift */; };
+		1DAD9EB62D3A6597001E9F49 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAD9EB52D3A6597001E9F49 /* Token.swift */; };
+		1DAD9EB82D3A7203001E9F49 /* ReissueTokenService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAD9EB72D3A7203001E9F49 /* ReissueTokenService.swift */; };
+		1DAD9EB92D3A84BA001E9F49 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAD9EB52D3A6597001E9F49 /* Token.swift */; };
 		1DBB55062C8418490009E033 /* LoginRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBB55052C8418490009E033 /* LoginRouter.swift */; };
 		1DBB55082C8421890009E033 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBB55072C8421890009E033 /* SignUpView.swift */; };
 		1DBB550A2C8421920009E033 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBB55092C8421920009E033 /* SignUpViewController.swift */; };
@@ -226,7 +236,6 @@
 		1D3523AB2D37E8BD007DD505 /* LoginResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponseDTO.swift; sourceTree = "<group>"; };
 		1D3523AF2D389B89007DD505 /* KeychainRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainRepository.swift; sourceTree = "<group>"; };
 		1D3523B12D390346007DD505 /* TokenSaveUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSaveUseCase.swift; sourceTree = "<group>"; };
-		1D3523B32D391C01007DD505 /* LoginInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginInteractorTests.swift; sourceTree = "<group>"; };
 		1D3972672C44185B00495014 /* RecipeListMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeListMapper.swift; sourceTree = "<group>"; };
 		1D39726B2C458CE100495014 /* MultipartFormDataRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataRequest.swift; sourceTree = "<group>"; };
 		1D39729D2C46C57A00495014 /* FetchRecipeDetailUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchRecipeDetailUseCaseTests.swift; sourceTree = "<group>"; };
@@ -268,6 +277,7 @@
 		1D93B9982CA26EB80094277F /* LoginUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCaseTests.swift; sourceTree = "<group>"; };
 		1D95A0A52C37C79500F09077 /* RecipeDetailError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeDetailError.swift; sourceTree = "<group>"; };
 		1D96FDA92C7F55E600EFC657 /* LoginInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginInteractor.swift; sourceTree = "<group>"; };
+		1DAD9EAA2D39F934001E9F49 /* LoginInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginInteractorTests.swift; sourceTree = "<group>"; };
 		1DBB55052C8418490009E033 /* LoginRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRouter.swift; sourceTree = "<group>"; };
 		1DBB55072C8421890009E033 /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
 		1DBB55092C8421920009E033 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
@@ -481,7 +491,7 @@
 				1D5AEF292C64730A00BBD5F0 /* FetchFeedListUseCaseTests.swift */,
 				1D8474552C6C917900323001 /* SearchFeedListUseCaseTests.swift */,
 				1D93B9982CA26EB80094277F /* LoginUseCaseTests.swift */,
-				1D3523B32D391C01007DD505 /* LoginInteractorTests.swift */,
+				1DAD9EAA2D39F934001E9F49 /* LoginInteractorTests.swift */,
 			);
 			path = HomeCafeRecipesTests;
 			sourceTree = "<group>";
@@ -975,8 +985,9 @@
 				1D6958D82C3D5A80008604B3 /* RecipeDeatilInteractorTests.swift in Sources */,
 				1DC373A82CA8169F00B2E831 /* LoginUseCase.swift in Sources */,
 				1D5AEE812C61099900BBD5F0 /* RecipeListInteractorTests.swift in Sources */,
-				1D3523B42D391C01007DD505 /* LoginInteractorTests.swift in Sources */,
+				1DAD9EAB2D39F934001E9F49 /* LoginInteractorTests.swift in Sources */,
 				1D60CC402C3EB76600D08FA3 /* APIConfig.swift in Sources */,
+				1DAD9EB92D3A84BA001E9F49 /* Token.swift in Sources */,
 				1D5AEF3A2C64795900BBD5F0 /* SearchFeedListRepository.swift in Sources */,
 				1DF0D19C2C7B92D600E2C94C /* UserDTO.swift in Sources */,
 				1D5AEF282C646FE600BBD5F0 /* RecipeListInteractor.swift in Sources */,
@@ -992,13 +1003,18 @@
 				1D166D0E2C4AD54E00A50963 /* AddRecipeViewModel.swift in Sources */,
 				1DC373A92CA81AD400B2E831 /* LoginError.swift in Sources */,
 				1D39729C2C45905700495014 /* MultipartFormDataRequest.swift in Sources */,
+				1DAD9EAD2D39FB49001E9F49 /* LoginInteractor.swift in Sources */,
 				1D5AEF332C64790200BBD5F0 /* RecipeUploadDTO.swift in Sources */,
+				1DAD9EAE2D3A3D98001E9F49 /* LoginResponseDTO.swift in Sources */,
 				1DF0D1A22C7B92F800E2C94C /* User.swift in Sources */,
 				1DC373A72CA810BB00B2E831 /* LoginRepository.swift in Sources */,
 				1D2C16FD2BE532B800C04508 /* HomeCafeRecipesTests.swift in Sources */,
 				1D6958E42C3D5EA6008604B3 /* NetworkResponseDTO.swift in Sources */,
 				1D5AEF302C6478D800BBD5F0 /* RecipeFetchService.swift in Sources */,
+				1DAD9EB02D3A3DC3001E9F49 /* LoginViewModel.swift in Sources */,
+				1DAD9EAC2D39FB43001E9F49 /* TokenSaveUseCase.swift in Sources */,
 				1D5AEF362C64791300BBD5F0 /* RecipePageDTO.swift in Sources */,
+				1DAD9EAF2D3A3DA5001E9F49 /* KeychainRepository.swift in Sources */,
 				1D5AEF322C6478FE00BBD5F0 /* RecipePostService.swift in Sources */,
 				1D6958DB2C3D5C91008604B3 /* Recipe.swift in Sources */,
 				1D6958E02C3D5E3D008604B3 /* RecipeDetailError.swift in Sources */,

--- a/HomeCafeRecipes/HomeCafeRecipes.xcodeproj/project.pbxproj
+++ b/HomeCafeRecipes/HomeCafeRecipes.xcodeproj/project.pbxproj
@@ -126,7 +126,6 @@
 		1DAD9EB42D3A6223001E9F49 /* ReissueTokenRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAD9EB32D3A6223001E9F49 /* ReissueTokenRepository.swift */; };
 		1DAD9EB62D3A6597001E9F49 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAD9EB52D3A6597001E9F49 /* Token.swift */; };
 		1DAD9EB82D3A7203001E9F49 /* ReissueTokenService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAD9EB72D3A7203001E9F49 /* ReissueTokenService.swift */; };
-		1DAD9EB92D3A84BA001E9F49 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAD9EB52D3A6597001E9F49 /* Token.swift */; };
 		1DBB55062C8418490009E033 /* LoginRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBB55052C8418490009E033 /* LoginRouter.swift */; };
 		1DBB55082C8421890009E033 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBB55072C8421890009E033 /* SignUpView.swift */; };
 		1DBB550A2C8421920009E033 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBB55092C8421920009E033 /* SignUpViewController.swift */; };
@@ -278,6 +277,10 @@
 		1D95A0A52C37C79500F09077 /* RecipeDetailError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeDetailError.swift; sourceTree = "<group>"; };
 		1D96FDA92C7F55E600EFC657 /* LoginInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginInteractor.swift; sourceTree = "<group>"; };
 		1DAD9EAA2D39F934001E9F49 /* LoginInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginInteractorTests.swift; sourceTree = "<group>"; };
+		1DAD9EB12D3A61AA001E9F49 /* ReissueTokenUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReissueTokenUseCase.swift; sourceTree = "<group>"; };
+		1DAD9EB32D3A6223001E9F49 /* ReissueTokenRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReissueTokenRepository.swift; sourceTree = "<group>"; };
+		1DAD9EB52D3A6597001E9F49 /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
+		1DAD9EB72D3A7203001E9F49 /* ReissueTokenService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReissueTokenService.swift; sourceTree = "<group>"; };
 		1DBB55052C8418490009E033 /* LoginRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRouter.swift; sourceTree = "<group>"; };
 		1DBB55072C8421890009E033 /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
 		1DBB55092C8421920009E033 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
@@ -379,6 +382,7 @@
 				1DD4F7092C80C947003E9D9D /* LoginError.swift */,
 				1D2398B32C8DC23500626F0C /* SignUpError.swift */,
 				1D0173AD2CB171DF00FF04BA /* Comment.swift */,
+				1DAD9EB52D3A6597001E9F49 /* Token.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -398,6 +402,7 @@
 				1DDF0FAE2D1AC71700B30426 /* ValidateEmailCodeUseCase.swift */,
 				1D2F4F752D2BEF6800FCE3A3 /* CheckNicknameUseCase.swift */,
 				1D3523B12D390346007DD505 /* TokenSaveUseCase.swift */,
+				1DAD9EB12D3A61AA001E9F49 /* ReissueTokenUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -434,6 +439,7 @@
 				1D919CC12D15968B004E6D7D /* SendVerificationCodeService.swift */,
 				1DDF0FB22D1ACE2D00B30426 /* EmailVerificationCodeService.swift */,
 				1D2F4F792D2BF1CC00FCE3A3 /* CheckNicknameService.swift */,
+				1DAD9EB72D3A7203001E9F49 /* ReissueTokenService.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -622,6 +628,7 @@
 				1DDF0FB02D1ACDA900B30426 /* EmailVerificationCodeRepository.swift */,
 				1D2F4F772D2BF10C00FCE3A3 /* CheckNicknameRepository.swift */,
 				1D3523AF2D389B89007DD505 /* KeychainRepository.swift */,
+				1DAD9EB32D3A6223001E9F49 /* ReissueTokenRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -880,6 +887,7 @@
 				1D2C6F652C2446D8004BB54E /* MainTabBarController.swift in Sources */,
 				1DD8739C2D0FF6CF007C8551 /* EmailVerificationViewController.swift in Sources */,
 				1DDFFD842C1C324F0083B077 /* RecipeDetailViewController.swift in Sources */,
+				1DAD9EB42D3A6223001E9F49 /* ReissueTokenRepository.swift in Sources */,
 				1D2C16E62BE532B700C04508 /* AppDelegate.swift in Sources */,
 				1D2F4F7C2D2BF45B00FCE3A3 /* CheckNicknameDTO.swift in Sources */,
 				1D5AEE512C592A8000BBD5F0 /* CGSize+addButton.swift in Sources */,
@@ -890,6 +898,7 @@
 				1DC7CC322C283C0200796889 /* RecipeUploadImgaeCell.swift in Sources */,
 				1D7368782C32E7FE000EF904 /* RecipePostService.swift in Sources */,
 				1D0635EA2CB2B0CD00DCC9EA /* CommentDTO.swift in Sources */,
+				1DAD9EB22D3A61AA001E9F49 /* ReissueTokenUseCase.swift in Sources */,
 				1D2398B42C8DC23500626F0C /* SignUpError.swift in Sources */,
 				1DBC63662C47D23000DA00C2 /* AddRecipeError.swift in Sources */,
 				1DDF0FB32D1ACE2D00B30426 /* EmailVerificationCodeService.swift in Sources */,
@@ -921,8 +930,10 @@
 				1DF829B42C2A7A7D00C337FC /* Fonts.swift in Sources */,
 				1DF0D1AD2C7DF9BB00E2C94C /* LoginView.swift in Sources */,
 				1D4741D22C1B4F8D009381CE /* RecipeDTO.swift in Sources */,
+				1DAD9EB62D3A6597001E9F49 /* Token.swift in Sources */,
 				1DE19EC02C1B422F0031804A /* RecipeDetailView.swift in Sources */,
 				1DF0D1982C7B92C500E2C94C /* DateFormatter+Extensions.swift in Sources */,
+				1DAD9EB82D3A7203001E9F49 /* ReissueTokenService.swift in Sources */,
 				1DBB55062C8418490009E033 /* LoginRouter.swift in Sources */,
 				1D1283AA2C15EBCF00C5A870 /* SearchFeedUseCase.swift in Sources */,
 				1D0BE5822CB5652500F54A26 /* CommnetMapper.swift in Sources */,

--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/LoginResponseDTO.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Network/DTO/LoginResponseDTO.swift
@@ -11,3 +11,12 @@ struct LoginResponseDTO: Decodable {
     let accessToken: String
     let refreshToken: String
 }
+
+extension LoginResponseDTO {
+    func toDomain() -> Token {
+        return Token(
+            accessToken: accessToken,
+            refreshToken: refreshToken
+        )
+    }
+}

--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Network/LoginService.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Network/LoginService.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 protocol LoginService {
-    func login(userID: String, password: String) -> Single<Result<LoginResponseDTO, LoginError>>
+    func login(userID: String, password: String) -> Single<Result<Token, LoginError>>
 }
 
 final class LoginServiceImpl: LoginService {
@@ -24,7 +24,7 @@ final class LoginServiceImpl: LoginService {
         return APIConfig().baseURL.appendingPathComponent(ednpoint)
     }
     
-    func login(userID: String, password: String) -> Single<Result<LoginResponseDTO, LoginError>> {
+    func login(userID: String, password: String) -> Single<Result<Token, LoginError>> {
         let url = makeURL(ednpoint: "auth/login")
         
         let parameters: [String: Any] = [
@@ -36,10 +36,10 @@ final class LoginServiceImpl: LoginService {
             url: url,
             parameters: parameters,
             responseType: NetworkResponseDTO<LoginResponseDTO>.self
-        )        
+        )
         .map { response in
             if response.statusCode == 200 {
-                return .success(response.data)
+                return .success(response.data.toDomain())
             } else {
                 return .failure(.serverError(response.message))
             }

--- a/HomeCafeRecipes/HomeCafeRecipes/Data/Repositories/LoginRepository.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Data/Repositories/LoginRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 protocol LoginRepository {
-    func login(userID: String, password: String) -> Single<Result<LoginResponseDTO, LoginError>>
+    func login(userID: String, password: String) -> Single<Result<Token, LoginError>>
 }
 
 final class LoginRepositoryImpl: LoginRepository {
@@ -21,7 +21,7 @@ final class LoginRepositoryImpl: LoginRepository {
         self.loginService = loginService
     }
     
-    func login(userID: String, password: String) -> Single<Result<LoginResponseDTO, LoginError>> {
+    func login(userID: String, password: String) -> Single<Result<Token, LoginError>> {
         return loginService.login(userID: userID, password: password)
             .catch { error in                
                 if let urlError = error as? URLError {

--- a/HomeCafeRecipes/HomeCafeRecipes/Domain/Entities/Token.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Domain/Entities/Token.swift
@@ -1,0 +1,13 @@
+//
+//  Token.swift
+//  HomeCafeRecipes
+//
+//  Created by 김건호 on 1/17/25.
+//
+
+import Foundation
+
+struct Token {
+    let accessToken: String
+    let refreshToken: String?
+}

--- a/HomeCafeRecipes/HomeCafeRecipes/Domain/Interactor/LoginInteractor.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Domain/Interactor/LoginInteractor.swift
@@ -29,7 +29,7 @@ final class LoginInteractorImpl: LoginInteractor {
     private let loginUseCase: LoginUseCase
     private let tokenSaveUseCase: TokenSaveUseCase
     
-    init(loginUseCase: LoginUseCase,tokensaveUsecase: TokenSaveUseCase) {
+    init(loginUseCase: LoginUseCase, tokensaveUsecase: TokenSaveUseCase) {
         self.loginUseCase = loginUseCase
         self.tokenSaveUseCase = tokensaveUsecase
     }
@@ -42,9 +42,18 @@ final class LoginInteractorImpl: LoginInteractor {
         .flatMap{ result in
             switch result {
             case .success(let loginResponse):
+                guard let refreshToken = loginResponse.refreshToken else {
+                    return .just(.failure(.genericError(
+                        NSError(
+                            domain: "TokenError",
+                            code: -1,
+                            userInfo: [NSLocalizedDescriptionKey: "Missing token"]
+                        )
+                    )))
+                }
                 self.tokenSaveUseCase.saveTokens(
                     accessToken: loginResponse.accessToken,
-                    refreshToken: loginResponse.refreshToken
+                    refreshToken: refreshToken
                 )
                 return .just(.success(true))
             case .failure(let error):

--- a/HomeCafeRecipes/HomeCafeRecipes/Domain/UseCases/LoginUseCase.swift
+++ b/HomeCafeRecipes/HomeCafeRecipes/Domain/UseCases/LoginUseCase.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 protocol LoginUseCase {
-    func execute(userID: String, password: String) -> Single<Result<LoginResponseDTO,LoginError>>
+    func execute(userID: String, password: String) -> Single<Result<Token,LoginError>>
 }
 
 class LoginUseCaseImpl: LoginUseCase {
@@ -20,7 +20,7 @@ class LoginUseCaseImpl: LoginUseCase {
         self.repository = repository
     }
     
-    func execute(userID: String, password: String) -> Single<Result<LoginResponseDTO, LoginError>> {
+    func execute(userID: String, password: String) -> Single<Result<Token, LoginError>> {
         guard !userID.isBlank else {
             return .just(.failure(.IDIsEmpty))
         }

--- a/HomeCafeRecipes/HomeCafeRecipesTests/LoginInteractorTests.swift
+++ b/HomeCafeRecipes/HomeCafeRecipesTests/LoginInteractorTests.swift
@@ -1,0 +1,82 @@
+//
+//  LoginInteractorTests.swift
+//  HomeCafeRecipesTests
+//
+//  Created by 김건호 on 1/17/25.
+//
+
+import XCTest
+
+import RxSwift
+
+@testable
+import HomeCafeRecipes
+
+final class LoginInteractorTests: XCTestCase {
+    
+    var loginUsecase: LoginUsecaseMock!
+    var tokensaveUsecase: TokenSaveUsecaseMock!
+    var disposeBag: DisposeBag!
+    
+    
+    final class LoginUsecaseMock: LoginUseCase {
+        var loginUsecaseCallCount: Int = 0
+        var executeStub: Single<Result<Token, LoginError>> = .just(
+            .success(
+                Token(
+                    accessToken: "testAccessToken",
+                    refreshToken: "testRefreshToken"
+                )
+            )
+        )
+        func execute(userID: String, password: String) -> Single<Result<Token, LoginError>> {
+            loginUsecaseCallCount += 1
+            return executeStub
+        }
+    }
+    
+    
+    final class TokenSaveUsecaseMock: TokenSaveUseCase {
+        var tokensaveCallCount: Int = 0
+        var savedAccessToken: String?
+        var savedRefreshToken: String?
+        
+        func saveTokens(accessToken: String, refreshToken: String) {
+            tokensaveCallCount += 1
+            savedAccessToken = accessToken
+            savedRefreshToken = refreshToken
+        }
+    }
+    
+    func createInteractor() -> LoginInteractor {
+        let interactor = LoginInteractorImpl(
+            loginUseCase: loginUsecase,
+            tokensaveUsecase: tokensaveUsecase
+        )
+        return interactor
+    }
+    
+    override func setUpWithError() throws {
+        loginUsecase = LoginUsecaseMock()
+        tokensaveUsecase = TokenSaveUsecaseMock()
+        disposeBag = DisposeBag()
+    }
+    
+    func test_로그인_성공시_토큰저장_호출합니다() {
+        // Given
+        let interactor = createInteractor()
+        let expectedAccessToken = "testAccessToken"
+        let expectedRefreshToken = "testRefreshToken"
+        
+        // When
+        interactor.login(userID: "testID", password: "testPassword")
+            .subscribe()
+            .disposed(by: disposeBag)
+        
+        // Then
+        XCTAssertEqual(loginUsecase.loginUsecaseCallCount, 1, "LoginUsecaseMock의 execute 메서드가 호출되지 않았습니다.")
+        XCTAssertEqual(tokensaveUsecase.tokensaveCallCount, 1, "TokenSaveUsecaseMock의 saveTokens 메서드가 호출되지 않았습니다.")
+        XCTAssertEqual(tokensaveUsecase.savedAccessToken, expectedAccessToken, "저장된 AccessToken이 예상과 다릅니다.")
+        XCTAssertEqual(tokensaveUsecase.savedRefreshToken, expectedRefreshToken, "저장된 RefreshToken이 예상과 다릅니다.")
+    }
+}


### PR DESCRIPTION
### PR 개요
로그인 로직 리팩토링 및 테스트 코드 추가

---
### 주요 변경 사항

1. Token 엔티티 선언 및 적용
   - 기존 LoginResponseDTO를 Token 엔티티로 매핑하여 비즈니스 로직에 적용.
   - LoginResponseDTO에 toDomain() 메서드를 추가하여 엔티티로 변환 가능하도록 수정.

2. 비즈니스 로직 수정
   - LoginUseCase와 LoginInteractor에서 Token 엔티티를 활용하도록 로직을 변경.

3. 테스트 코드 작성 및 수정
   - LoginUseCaseTests에 Token 엔티티를 반환을 검증하는 테스트 추가
   - 입력값 검증 실패시 repository.loginCallCount == 0 확인
   - LoginInteractorTests에 TokenSaveUseCase 호출 여부를 검증하는 테스트 추가

---
### 테스트 결과
![스크린샷 2025-01-17 오후 9 54 12](https://github.com/user-attachments/assets/954cb89f-c2ef-4e08-8426-b73ebbc1d31f)
